### PR TITLE
feat: add provider-backed MVP image API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/data
 
 # misc
 .DS_Store
@@ -21,5 +22,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+firebase-debug.log
 .env
 photograma-c2078-firebase-adminsdk-ax4wk-d70d1dfd8e.json

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Photogram Backend (Image Upload Service)
 
-Express service for resizing, uploading, and deleting images in Firebase Storage. The app is modularized into `app.js`, `routes/`, `controllers/`, `middleware/`, `config/`, and `utils/`.
+Express service for resizing, uploading, deleting, and listing Photogram images. Legacy Firebase Storage endpoints remain available, and the provider-backed MVP can run with Firebase Auth, SQLite metadata, and local filesystem storage.
 
 ## Features
 - Resize to 1440px width and compress to JPEG (quality 80) via `/resize`.
 - Upload original image to Firebase Storage via `/upload`.
 - Resize then upload via `/resize-upload`.
 - Delete images from Firebase Storage via `/delete-image`.
+- Provider-backed image API at `/images/*` for local MVP mode.
+- Public local media serving at `/media/*` when `STORAGE_PROVIDER=local`.
 - Health/debug endpoints plus size limits and a CORS allowlist.
 
 ## Prerequisites
@@ -20,21 +22,89 @@ Set environment variables as needed:
 | Variable | Description | Default |
 | --- | --- | --- |
 | `PORT` | HTTP port | `3000` |
+| `AUTH_PROVIDER` | Auth provider (`firebase` or future `local`) | `firebase` |
+| `DATABASE_PROVIDER` | Metadata provider (`sqlite` or future `firebase`) | `sqlite` |
+| `STORAGE_PROVIDER` | Image storage provider (`local` or future `firebase`) | `local` |
+| `SQLITE_PATH` | SQLite metadata database path for local MVP mode | `./data/photogram.sqlite` |
+| `LOCAL_STORAGE_ROOT` | Local image storage root | `./data/images` |
+| `PUBLIC_MEDIA_BASE_URL` | Public URL base for local media URLs | `http://localhost:3000/media` |
 | `MAX_FILE_SIZE_MB` | Upload limit (in MB) | `5` |
 | `RESIZE_CONCURRENCY` | Max concurrent resize jobs (guardrailed by memory profile) | `1` |
-| `LOW_MEMORY_MODE` | Memory profile mode (`auto`, `true`, `false`) used for safety caps | `auto` |
+| `LOW_MEMORY_MODE` | Memory profile mode (`true` or `false`) used for safety caps | `true` |
 | `DEFAULT_RATE_LIMIT_MAX` | Per-minute limit for light endpoints | `60` |
-| `HEAVY_RATE_LIMIT_MAX` | Per-minute limit for heavy endpoints (`/resize`, `/resize-upload`) | `8` on low-memory, `20` otherwise |
-| `ENABLE_DEBUG_ENDPOINT` | Enable `/debug` endpoint (`auto`, `true`, `false`) | `auto` (`false` in production) |
+| `HEAVY_RATE_LIMIT_MAX` | Per-minute limit for heavy endpoints (`/resize`, `/resize-upload`, `POST /images`) | `8` |
+| `ENABLE_DEBUG_ENDPOINT` | Enable `/debug` endpoint (`true` or `false`) | `false` |
 | `UPLOAD_TEMP_CLEANUP_ENABLED` | Enable periodic cleanup of stale temp upload files | `true` |
 | `UPLOAD_TEMP_CLEANUP_INTERVAL_SECONDS` | Temp cleanup interval in seconds | `300` |
 | `UPLOAD_TEMP_STALE_AGE_SECONDS` | File age threshold for deletion in seconds | `900` |
 | `FIREBASE_SERVICE_ACCOUNT_PATH` | Path to service account JSON | **required** (no fallback) |
-| `FIREBASE_STORAGE_BUCKET` | Firebase Storage bucket name | `photograma-c2078.appspot.com` |
+| `FIREBASE_STORAGE_BUCKET` | Firebase Storage bucket name; required when `STORAGE_PROVIDER=firebase` | none |
 | `IMAGE_PROCESSOR` | Image engine for `/resize` + `/resize-upload` (`sharp` or `jimp`) | `sharp` |
 | `FIREBASE_UPLOAD_ACL` | GCS predefined ACL for uploads (`publicRead`, etc). Set `none` to rely on bucket policy. | `publicRead` |
-| `FIREBASE_URL_MODE` | Upload response URL type (`public` or `signed`) | `public` |
-| `FIREBASE_SIGNED_URL_EXPIRES_SECONDS` | Signed URL TTL in seconds (used when `FIREBASE_URL_MODE=signed`) | `900` |
+| `FIREBASE_URL_MODE` | Upload response URL type (`public` or `signed`) | `signed` |
+| `FIREBASE_SIGNED_URL_EXPIRES_SECONDS` | Signed URL TTL in seconds (used when `FIREBASE_URL_MODE=signed`) | `300` |
+
+## Provider-Backed MVP Mode
+Use this mode for the current Samsung NC110 target while keeping Firebase Auth:
+
+```bash
+AUTH_PROVIDER=firebase \
+DATABASE_PROVIDER=sqlite \
+STORAGE_PROVIDER=local \
+SQLITE_PATH=./data/photogram.sqlite \
+LOCAL_STORAGE_ROOT=./data/images \
+PUBLIC_MEDIA_BASE_URL=http://localhost:3000/media \
+FIREBASE_SERVICE_ACCOUNT_PATH=/secure/photogram/firebase-service-account.json \
+LOW_MEMORY_MODE=true \
+MAX_FILE_SIZE_MB=5 \
+RESIZE_CONCURRENCY=1 \
+HEAVY_RATE_LIMIT_MAX=8 \
+ENABLE_DEBUG_ENDPOINT=false \
+IMAGE_PROCESSOR=sharp \
+npm start
+```
+
+Canonical provider-backed routes:
+
+- `GET /images/public`
+- `GET /images/me`
+- `POST /images`
+- `DELETE /images/:imageId`
+- `PATCH /images/:imageId/visibility`
+- `POST /images/:imageId/archive`
+- `POST /images/:imageId/unarchive`
+- `GET /media/*`
+
+Quick validation:
+
+```bash
+npm install
+npm test
+node --check index.js
+node --check app.js
+
+curl http://localhost:3000/health
+curl http://localhost:3000/images/public
+curl -H "Authorization: Bearer <firebase-id-token>" http://localhost:3000/images/me
+curl -X POST -H "Authorization: Bearer <firebase-id-token>" \
+  -F "image=@/path/to/photo.jpg" \
+  -F "description=Provider-backed upload" \
+  -F "isPublic=true" \
+  http://localhost:3000/images
+curl -X DELETE -H "Authorization: Bearer <firebase-id-token>" \
+  http://localhost:3000/images/<image-id>
+curl -X PATCH -H "Authorization: Bearer <firebase-id-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"isPublic":false}' \
+  http://localhost:3000/images/<image-id>/visibility
+curl -X POST -H "Authorization: Bearer <firebase-id-token>" \
+  http://localhost:3000/images/<image-id>/archive
+curl -X POST -H "Authorization: Bearer <firebase-id-token>" \
+  http://localhost:3000/images/<image-id>/unarchive
+curl http://localhost:3000/media/users/<uid>/images/<image-id>.jpg
+```
+
+Upload edge cases to validate before deployment: valid image, non-image file, empty payload, and oversize payload using `MAX_FILE_SIZE_MB`.
 
 ## Setup
 ```bash
@@ -53,6 +123,14 @@ All endpoints expect `multipart/form-data` with the file field named `image` unl
 - `POST /upload` — Upload original image to Firebase Storage and return `{ url }`.
 - `POST /resize-upload` — Resize/compress, upload to Storage, and return `{ url }`.
 - `POST /delete-image` — JSON body `{ "imgName": "file-name.jpg" }` to delete from `images/` in the bucket.
+- `GET /images/public` — List public provider-backed image DTOs.
+- `GET /images/me` — List authenticated user's provider-backed image DTOs.
+- `POST /images` — Authenticated provider-backed upload using the `image` form field.
+- `DELETE /images/:imageId` — Authenticated provider-backed delete.
+- `PATCH /images/:imageId/visibility` — Authenticated owner visibility update.
+- `POST /images/:imageId/archive` — Authenticated owner archive action.
+- `POST /images/:imageId/unarchive` — Authenticated owner unarchive action.
+- `GET /media/*` — Serve local media only when local storage is selected.
 - `GET /health` — Returns `OK`.
 - `GET /debug` — Returns basic request info (IP, region).
 
@@ -61,21 +139,21 @@ Allowed origins are defined in `middleware/cors.js` (`apps.andreszenteno.com`, l
 
 ## Notes
 - Only image uploads are accepted; non-image requests are rejected with `400`.
-- On low-memory hosts (`LOW_MEMORY_MODE=true` or auto-detected), runtime guardrails clamp `MAX_FILE_SIZE_MB` to `10` and `RESIZE_CONCURRENCY` to `1`.
+- On low-memory hosts (`LOW_MEMORY_MODE=true`), runtime guardrails clamp `MAX_FILE_SIZE_MB` to `10` and `RESIZE_CONCURRENCY` to `1`.
 - Heavy endpoint rate limit is also clamped in low-memory mode (`HEAVY_RATE_LIMIT_MAX` cap `12`, default `8`).
 - `FIREBASE_SERVICE_ACCOUNT_PATH` is required. Do not rely on in-repo credential files.
 - For private workflows, set `FIREBASE_URL_MODE=signed` so upload endpoints return time-limited signed URLs instead of public object URLs.
-- `/debug` is disabled by default in production unless `ENABLE_DEBUG_ENDPOINT=true`.
+- `/debug` is disabled by default unless `ENABLE_DEBUG_ENDPOINT=true`.
 - Some very old CPUs (e.g. Atom-era netbooks) may crash when loading `sharp`/libvips (`invalid opcode` / `SIGILL`). If that happens, set `IMAGE_PROCESSOR=jimp` (higher CPU/RAM), or rebuild `sharp` on that machine against a compatible libvips.
 
 ## Breaking Changes (v2.0.0)
 - `FIREBASE_SERVICE_ACCOUNT_PATH` is now required. Startup will fail if it is missing or invalid.
 - Runtime defaults now include low-memory guardrails:
-  - `LOW_MEMORY_MODE=auto` (auto-detects low-memory hosts)
+  - `LOW_MEMORY_MODE=true`
   - low-memory clamp for `MAX_FILE_SIZE_MB` (cap `10`)
   - low-memory clamp for `RESIZE_CONCURRENCY` (cap `1`)
 - Rate limits are now configurable and guardrailed:
   - `DEFAULT_RATE_LIMIT_MAX`
   - `HEAVY_RATE_LIMIT_MAX` (defaults lower on low-memory hosts, with caps)
 - `/debug` endpoint behavior changed:
-  - `ENABLE_DEBUG_ENDPOINT=auto` means disabled by default in `NODE_ENV=production`.
+  - `ENABLE_DEBUG_ENDPOINT=false` disables it unless explicitly enabled.

--- a/app.js
+++ b/app.js
@@ -2,7 +2,6 @@ require('dotenv').config();
 
 const express = require('express');
 
-const { bucket } = require('./config/firebase');
 const {
     LOW_MEMORY_MODE,
     MAX_FILE_SIZE_MB,
@@ -27,13 +26,15 @@ const { corsMiddleware } = require('./middleware/cors');
 const { multerErrorHandler, fallbackErrorHandler } = require('./middleware/errorHandlers');
 const { createMultipartSizeGuard } = require('./middleware/multipartSizeGuard');
 const { createRateLimiters } = require('./middleware/rateLimiters');
+const { createStaticMediaMiddleware } = require('./middleware/staticMedia');
 const { createUploadMiddleware } = require('./middleware/upload');
+const { createImageApiRoutes } = require('./routes/imageApiRoutes');
 const { createImageRouter } = require('./routes/imageRoutes');
 const { createSystemRouter } = require('./routes/systemRoutes');
 const { log } = require('./utils/logger');
 const { createSemaphore } = require('./utils/semaphore');
 
-const createApp = () => {
+const createApp = ({ container, legacyBucket, legacyBucketGetter } = {}) => {
     const app = express();
 
     log('info', 'Configured runtime limits', {
@@ -86,7 +87,8 @@ const createApp = () => {
     const resizeSemaphore = createSemaphore(RESIZE_CONCURRENCY);
 
     const imageController = createImageController({
-        bucket,
+        bucket: legacyBucket,
+        bucketGetter: legacyBucketGetter,
         imageProcessor: IMAGE_PROCESSOR,
         uploadAcl: FIREBASE_UPLOAD_ACL,
         usePredefinedAcl,
@@ -106,6 +108,29 @@ const createApp = () => {
             imageController,
         }),
     );
+
+    if (container) {
+        app.use('/images', createImageApiRoutes({
+            imageService: container.imageService,
+            imageUploadService: container.imageUploadService,
+            authProvider: container.authProvider,
+            heavyLimiter,
+            multipartSizeGuard,
+            upload,
+            resizeSemaphore,
+        }));
+    }
+
+    if (
+        container
+        && container.config
+        && container.config.storageProvider === 'local'
+        && container.storageProvider
+    ) {
+        app.use('/media', createStaticMediaMiddleware({
+            storageProvider: container.storageProvider,
+        }));
+    }
 
     app.use(multerErrorHandler);
     app.use(fallbackErrorHandler);

--- a/auth/firebaseAuthProvider.js
+++ b/auth/firebaseAuthProvider.js
@@ -1,0 +1,95 @@
+const createUnauthorizedError = (message) => {
+    const error = new Error(message);
+    error.statusCode = 401;
+    error.code = 'UNAUTHENTICATED';
+    return error;
+};
+
+const getAuthorizationHeader = (req) => {
+    if (!req || !req.headers) return null;
+    return req.headers.authorization || req.headers.Authorization || null;
+};
+
+const parseBearerToken = (authorizationHeader) => {
+    if (!authorizationHeader) return null;
+
+    const parts = authorizationHeader.trim().split(/\s+/);
+    if (parts.length !== 2 || parts[0].toLowerCase() !== 'bearer') {
+        throw createUnauthorizedError('Authorization header must use the Bearer scheme.');
+    }
+
+    if (!parts[1]) {
+        throw createUnauthorizedError('Bearer token must not be empty.');
+    }
+
+    return parts[1];
+};
+
+const resolveFirebaseAuth = () => {
+    const { getAuth } = require('../config/firebase');
+    return getAuth();
+};
+
+const normalizeUser = (decodedToken) => {
+    const uid = decodedToken && (decodedToken.uid || decodedToken.user_id || decodedToken.sub);
+    if (!uid) {
+        throw createUnauthorizedError('Verified Firebase token does not contain a usable UID.');
+    }
+
+    return {
+        uid,
+        email: decodedToken.email ?? null,
+        emailVerified: decodedToken.email_verified ?? decodedToken.emailVerified ?? false,
+        displayName: decodedToken.name ?? decodedToken.displayName ?? null,
+        photoUrl: decodedToken.picture ?? decodedToken.photoUrl ?? null,
+        claims: decodedToken,
+    };
+};
+
+function createFirebaseAuthProvider({ config, firebaseAuth } = {}) {
+    let resolvedFirebaseAuth = firebaseAuth;
+
+    const getFirebaseAuth = () => {
+        if (!resolvedFirebaseAuth) {
+            resolvedFirebaseAuth = resolveFirebaseAuth();
+        }
+
+        if (!resolvedFirebaseAuth || typeof resolvedFirebaseAuth.verifyIdToken !== 'function') {
+            throw createUnauthorizedError('Firebase Auth verifier is not available.');
+        }
+
+        return resolvedFirebaseAuth;
+    };
+
+    const getCurrentUser = async (req) => {
+        const token = parseBearerToken(getAuthorizationHeader(req));
+        if (!token) return null;
+
+        let decodedToken;
+        try {
+            decodedToken = await getFirebaseAuth().verifyIdToken(token);
+        } catch (error) {
+            throw createUnauthorizedError(`Invalid Firebase ID token: ${error.message}`);
+        }
+
+        return normalizeUser(decodedToken);
+    };
+
+    const requireUser = async (req) => {
+        const user = await getCurrentUser(req);
+        if (!user) {
+            throw createUnauthorizedError('Authentication is required.');
+        }
+
+        return user;
+    };
+
+    return {
+        getCurrentUser,
+        requireUser,
+    };
+}
+
+module.exports = {
+    createFirebaseAuthProvider,
+};

--- a/config/container.js
+++ b/config/container.js
@@ -1,0 +1,95 @@
+const { createImageProcessor } = require('../services/imageProcessor');
+const { createImagePresenter } = require('../services/imagePresenter');
+const { createImageService } = require('../services/imageService');
+const { createImageUploadService } = require('../services/imageUploadService');
+
+const requireObject = (value, name) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error(`${name} must be an object.`);
+    }
+    return value;
+};
+
+const resolveFactory = (registry, providerName, envName, providerType) => {
+    const factory = registry[providerName];
+
+    if (factory === undefined) {
+        throw new Error(`${envName} selected "${providerName}", but no ${providerType} factory is registered.`);
+    }
+
+    if (typeof factory !== 'function') {
+        throw new Error(`${envName} selected "${providerName}", but the ${providerType} registry value must be a function.`);
+    }
+
+    return factory;
+};
+
+const createProvider = (factory, providerType, context) => {
+    const provider = factory(context);
+
+    if (!provider || typeof provider !== 'object' || Array.isArray(provider)) {
+        throw new Error(`${providerType} factory must return an object.`);
+    }
+
+    return provider;
+};
+
+const createContainer = (config, providerRegistry) => {
+    requireObject(config, 'config');
+    requireObject(providerRegistry, 'providerRegistry');
+
+    const authProviders = requireObject(providerRegistry.authProviders, 'providerRegistry.authProviders');
+    const imageRepositories = requireObject(providerRegistry.imageRepositories, 'providerRegistry.imageRepositories');
+    const storageProviders = requireObject(providerRegistry.storageProviders, 'providerRegistry.storageProviders');
+
+    const authFactory = resolveFactory(authProviders, config.authProvider, 'AUTH_PROVIDER', 'auth provider');
+    const imageRepositoryFactory = resolveFactory(
+        imageRepositories,
+        config.databaseProvider,
+        'DATABASE_PROVIDER',
+        'image repository',
+    );
+    const storageProviderFactory = resolveFactory(
+        storageProviders,
+        config.storageProvider,
+        'STORAGE_PROVIDER',
+        'storage provider',
+    );
+
+    const context = { config };
+    const authProvider = createProvider(authFactory, 'auth provider', context);
+    const imageRepository = createProvider(imageRepositoryFactory, 'image repository', context);
+    const storageProvider = createProvider(storageProviderFactory, 'storage provider', context);
+    const imagePresenter = createImagePresenter({ storageProvider });
+    const imageService = createImageService({
+        imageRepository,
+        storageProvider,
+        imagePresenter,
+    });
+    const imageProcessor = createImageProcessor({
+        processorName: config.imageProcessor,
+    });
+    const imageUploadService = createImageUploadService({
+        config,
+        storageProvider,
+        imageService,
+        imageProcessor,
+    });
+
+    return {
+        config,
+        authProvider,
+        imageRepository,
+        storageProvider,
+        imagePresenter,
+        imageService,
+        imageUploadService,
+    };
+};
+
+module.exports = {
+    createContainer,
+    requireObject,
+    resolveFactory,
+    createProvider,
+};

--- a/config/env.js
+++ b/config/env.js
@@ -1,106 +1,188 @@
-const os = require('os');
+const DEFAULTS = {
+    NODE_ENV: 'development',
+    PORT: '3000',
+    AUTH_PROVIDER: 'firebase',
+    DATABASE_PROVIDER: 'sqlite',
+    STORAGE_PROVIDER: 'local',
+    SQLITE_PATH: './data/photogram.sqlite',
+    LOCAL_STORAGE_ROOT: './data/images',
+    PUBLIC_MEDIA_BASE_URL: 'http://localhost:3000/media',
+    FIREBASE_URL_MODE: 'signed',
+    FIREBASE_SIGNED_URL_EXPIRES_SECONDS: '300',
+    LOW_MEMORY_MODE: 'true',
+    MAX_FILE_SIZE_MB: '5',
+    RESIZE_CONCURRENCY: '1',
+    HEAVY_RATE_LIMIT_MAX: '8',
+    ENABLE_DEBUG_ENDPOINT: 'false',
+    IMAGE_PROCESSOR: 'sharp',
+    DEFAULT_RATE_LIMIT_MAX: '60',
+    UPLOAD_TEMP_CLEANUP_ENABLED: 'true',
+    UPLOAD_TEMP_CLEANUP_INTERVAL_SECONDS: '300',
+    UPLOAD_TEMP_STALE_AGE_SECONDS: '900',
+    FIREBASE_UPLOAD_ACL: 'publicRead',
+};
 
-const DEFAULT_MAX_FILE_SIZE_MB = 5;
-const DEFAULT_RESIZE_CONCURRENCY = 1;
-const DEFAULT_DEFAULT_RATE_LIMIT_MAX = 60;
-const LOW_MEMORY_HEAVY_RATE_LIMIT_MAX = 8;
-const STANDARD_HEAVY_RATE_LIMIT_MAX = 20;
-const LOW_MEMORY_HEAVY_RATE_LIMIT_CAP = 12;
-const STANDARD_HEAVY_RATE_LIMIT_CAP = 40;
-const DEFAULT_UPLOAD_TEMP_CLEANUP_INTERVAL_SECONDS = 300;
-const DEFAULT_UPLOAD_TEMP_STALE_AGE_SECONDS = 900;
-const LOW_MEMORY_THRESHOLD_BYTES = 3 * 1024 * 1024 * 1024;
+const AUTH_PROVIDERS = new Set(['firebase', 'local']);
+const DATABASE_PROVIDERS = new Set(['firebase', 'sqlite']);
+const STORAGE_PROVIDERS = new Set(['firebase', 'local']);
+const IMAGE_PROCESSORS = new Set(['sharp', 'jimp']);
+const FIREBASE_URL_MODES = new Set(['public', 'signed']);
+
 const LOW_MEMORY_MAX_FILE_SIZE_MB = 10;
 const STANDARD_MAX_FILE_SIZE_MB = 25;
 const LOW_MEMORY_RESIZE_CONCURRENCY_CAP = 1;
 const STANDARD_RESIZE_CONCURRENCY_CAP = 4;
+const LOW_MEMORY_HEAVY_RATE_LIMIT_CAP = 12;
+const STANDARD_HEAVY_RATE_LIMIT_CAP = 40;
 
-const normalizeBooleanMode = (value, fallback) => {
+const readValue = (source, envName) => {
+    const value = source[envName];
+    if (value === undefined || value === null || value === '') {
+        return DEFAULTS[envName];
+    }
+    return String(value);
+};
+
+const requireValue = (source, envName) => {
+    const value = source[envName];
+    if (value === undefined || value === null || String(value).trim() === '') {
+        throw new Error(`${envName} is required for the selected provider configuration.`);
+    }
+    return String(value);
+};
+
+const parseEnum = (source, envName, allowedValues) => {
+    const value = readValue(source, envName).toLowerCase();
+    if (!allowedValues.has(value)) {
+        throw new Error(`${envName} must be one of: ${Array.from(allowedValues).join(', ')}.`);
+    }
+    return value;
+};
+
+const parseBoolean = (source, envName) => {
+    const value = readValue(source, envName).toLowerCase();
     if (value === 'true') return true;
     if (value === 'false') return false;
-    return fallback;
+    throw new Error(`${envName} must be either true or false.`);
 };
 
-const toPositiveNumberOrDefault = (value, fallback) => {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+const parsePositiveInteger = (source, envName) => {
+    const raw = readValue(source, envName);
+    const value = Number(raw);
+    if (!Number.isInteger(value) || value <= 0) {
+        throw new Error(`${envName} must be a positive integer.`);
+    }
+    return value;
 };
 
-const toPositiveIntegerOrDefault = (value, fallback) => {
-    const parsed = Number(value);
-    return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+const clamp = (value, max) => Math.min(value, max);
+
+const readEnv = (source = process.env) => {
+    const nodeEnv = readValue(source, 'NODE_ENV');
+    const port = parsePositiveInteger(source, 'PORT');
+
+    const authProvider = parseEnum(source, 'AUTH_PROVIDER', AUTH_PROVIDERS);
+    const databaseProvider = parseEnum(source, 'DATABASE_PROVIDER', DATABASE_PROVIDERS);
+    const storageProvider = parseEnum(source, 'STORAGE_PROVIDER', STORAGE_PROVIDERS);
+
+    const lowMemoryMode = parseBoolean(source, 'LOW_MEMORY_MODE');
+    const requestedMaxFileSizeMb = parsePositiveInteger(source, 'MAX_FILE_SIZE_MB');
+    const requestedResizeConcurrency = parsePositiveInteger(source, 'RESIZE_CONCURRENCY');
+    const requestedHeavyRateLimitMax = parsePositiveInteger(source, 'HEAVY_RATE_LIMIT_MAX');
+
+    const maxFileSizeMbCap = lowMemoryMode ? LOW_MEMORY_MAX_FILE_SIZE_MB : STANDARD_MAX_FILE_SIZE_MB;
+    const resizeConcurrencyCap = lowMemoryMode ? LOW_MEMORY_RESIZE_CONCURRENCY_CAP : STANDARD_RESIZE_CONCURRENCY_CAP;
+    const heavyRateLimitCap = lowMemoryMode ? LOW_MEMORY_HEAVY_RATE_LIMIT_CAP : STANDARD_HEAVY_RATE_LIMIT_CAP;
+
+    const maxFileSizeMb = clamp(requestedMaxFileSizeMb, maxFileSizeMbCap);
+    const resizeConcurrency = clamp(requestedResizeConcurrency, resizeConcurrencyCap);
+    const heavyRateLimitMax = clamp(requestedHeavyRateLimitMax, heavyRateLimitCap);
+
+    const sqlitePath = databaseProvider === 'sqlite'
+        ? readValue(source, 'SQLITE_PATH')
+        : source.SQLITE_PATH ? String(source.SQLITE_PATH) : undefined;
+    const localStorageRoot = storageProvider === 'local'
+        ? readValue(source, 'LOCAL_STORAGE_ROOT')
+        : source.LOCAL_STORAGE_ROOT ? String(source.LOCAL_STORAGE_ROOT) : undefined;
+    const publicMediaBaseUrl = storageProvider === 'local'
+        ? readValue(source, 'PUBLIC_MEDIA_BASE_URL')
+        : source.PUBLIC_MEDIA_BASE_URL ? String(source.PUBLIC_MEDIA_BASE_URL) : undefined;
+
+    const usesFirebase = authProvider === 'firebase'
+        || databaseProvider === 'firebase'
+        || storageProvider === 'firebase';
+    const firebaseServiceAccountPath = usesFirebase
+        ? requireValue(source, 'FIREBASE_SERVICE_ACCOUNT_PATH')
+        : source.FIREBASE_SERVICE_ACCOUNT_PATH ? String(source.FIREBASE_SERVICE_ACCOUNT_PATH) : undefined;
+    const firebaseStorageBucket = storageProvider === 'firebase'
+        ? requireValue(source, 'FIREBASE_STORAGE_BUCKET')
+        : source.FIREBASE_STORAGE_BUCKET ? String(source.FIREBASE_STORAGE_BUCKET) : undefined;
+
+    const firebaseUrlMode = parseEnum(source, 'FIREBASE_URL_MODE', FIREBASE_URL_MODES);
+    const firebaseSignedUrlExpiresSeconds = parsePositiveInteger(source, 'FIREBASE_SIGNED_URL_EXPIRES_SECONDS');
+    const enableDebugEndpoint = parseBoolean(source, 'ENABLE_DEBUG_ENDPOINT');
+    const imageProcessor = parseEnum(source, 'IMAGE_PROCESSOR', IMAGE_PROCESSORS);
+
+    const defaultRateLimitMax = parsePositiveInteger(source, 'DEFAULT_RATE_LIMIT_MAX');
+    const uploadTempCleanupEnabled = parseBoolean(source, 'UPLOAD_TEMP_CLEANUP_ENABLED');
+    const uploadTempCleanupIntervalSeconds = parsePositiveInteger(source, 'UPLOAD_TEMP_CLEANUP_INTERVAL_SECONDS');
+    const uploadTempStaleAgeSeconds = parsePositiveInteger(source, 'UPLOAD_TEMP_STALE_AGE_SECONDS');
+    const firebaseUploadAcl = readValue(source, 'FIREBASE_UPLOAD_ACL');
+
+    return {
+        nodeEnv,
+        port,
+        authProvider,
+        databaseProvider,
+        storageProvider,
+        sqlitePath,
+        localStorageRoot,
+        publicMediaBaseUrl,
+        firebaseServiceAccountPath,
+        firebaseStorageBucket,
+        firebaseUrlMode,
+        firebaseSignedUrlExpiresSeconds,
+        lowMemoryMode,
+        maxFileSizeMb,
+        resizeConcurrency,
+        heavyRateLimitMax,
+        enableDebugEndpoint,
+        imageProcessor,
+        maxFileSizeBytes: maxFileSizeMb * 1024 * 1024,
+        maxFileSizeWasClamped: requestedMaxFileSizeMb > maxFileSizeMbCap,
+        resizeConcurrencyWasClamped: requestedResizeConcurrency > resizeConcurrencyCap,
+        heavyRateLimitWasClamped: requestedHeavyRateLimitMax > heavyRateLimitCap,
+        defaultRateLimitMax,
+        uploadTempCleanupEnabled,
+        uploadTempCleanupIntervalSeconds,
+        uploadTempStaleAgeSeconds,
+        firebaseUploadAcl,
+    };
 };
 
-const detectedLowMemoryMode = os.totalmem() <= LOW_MEMORY_THRESHOLD_BYTES;
-const LOW_MEMORY_MODE = normalizeBooleanMode(
-    (process.env.LOW_MEMORY_MODE || 'auto').toLowerCase(),
-    detectedLowMemoryMode,
-);
-
-const maxFileSizeMbCap = LOW_MEMORY_MODE ? LOW_MEMORY_MAX_FILE_SIZE_MB : STANDARD_MAX_FILE_SIZE_MB;
-const requestedMaxFileSizeMb = toPositiveNumberOrDefault(process.env.MAX_FILE_SIZE_MB, DEFAULT_MAX_FILE_SIZE_MB);
-const MAX_FILE_SIZE_MB = Math.min(requestedMaxFileSizeMb, maxFileSizeMbCap);
-const MAX_FILE_SIZE_WAS_CLAMPED = requestedMaxFileSizeMb > maxFileSizeMbCap;
-const MAX_FILE_SIZE = MAX_FILE_SIZE_MB * 1024 * 1024;
-
-const IMAGE_PROCESSOR = (process.env.IMAGE_PROCESSOR || 'sharp').toLowerCase();
-
-const resizeConcurrencyCap = LOW_MEMORY_MODE ? LOW_MEMORY_RESIZE_CONCURRENCY_CAP : STANDARD_RESIZE_CONCURRENCY_CAP;
-const requestedResizeConcurrency = toPositiveNumberOrDefault(process.env.RESIZE_CONCURRENCY, DEFAULT_RESIZE_CONCURRENCY);
-const RESIZE_CONCURRENCY = Math.min(Math.floor(requestedResizeConcurrency), resizeConcurrencyCap);
-const RESIZE_CONCURRENCY_WAS_CLAMPED = requestedResizeConcurrency > resizeConcurrencyCap;
-
-const defaultHeavyRateLimit = LOW_MEMORY_MODE ? LOW_MEMORY_HEAVY_RATE_LIMIT_MAX : STANDARD_HEAVY_RATE_LIMIT_MAX;
-const heavyRateLimitCap = LOW_MEMORY_MODE ? LOW_MEMORY_HEAVY_RATE_LIMIT_CAP : STANDARD_HEAVY_RATE_LIMIT_CAP;
-const requestedHeavyRateLimit = toPositiveIntegerOrDefault(process.env.HEAVY_RATE_LIMIT_MAX, defaultHeavyRateLimit);
-const HEAVY_RATE_LIMIT_MAX = Math.min(requestedHeavyRateLimit, heavyRateLimitCap);
-const HEAVY_RATE_LIMIT_WAS_CLAMPED = requestedHeavyRateLimit > heavyRateLimitCap;
-
-const DEFAULT_RATE_LIMIT_MAX = toPositiveIntegerOrDefault(process.env.DEFAULT_RATE_LIMIT_MAX, DEFAULT_DEFAULT_RATE_LIMIT_MAX);
-const ENABLE_DEBUG_ENDPOINT = normalizeBooleanMode(
-    (process.env.ENABLE_DEBUG_ENDPOINT || 'auto').toLowerCase(),
-    process.env.NODE_ENV !== 'production',
-);
-const UPLOAD_TEMP_CLEANUP_ENABLED = normalizeBooleanMode(
-    (process.env.UPLOAD_TEMP_CLEANUP_ENABLED || 'true').toLowerCase(),
-    true,
-);
-const UPLOAD_TEMP_CLEANUP_INTERVAL_SECONDS = toPositiveIntegerOrDefault(
-    process.env.UPLOAD_TEMP_CLEANUP_INTERVAL_SECONDS,
-    DEFAULT_UPLOAD_TEMP_CLEANUP_INTERVAL_SECONDS,
-);
-const UPLOAD_TEMP_STALE_AGE_SECONDS = toPositiveIntegerOrDefault(
-    process.env.UPLOAD_TEMP_STALE_AGE_SECONDS,
-    DEFAULT_UPLOAD_TEMP_STALE_AGE_SECONDS,
-);
-
-const FIREBASE_STORAGE_BUCKET = process.env.FIREBASE_STORAGE_BUCKET || 'photograma-c2078.appspot.com';
-const FIREBASE_UPLOAD_ACL = process.env.FIREBASE_UPLOAD_ACL || 'publicRead';
-const FIREBASE_URL_MODE = (process.env.FIREBASE_URL_MODE || 'public').toLowerCase();
-const signedUrlExpiresSecondsEnv = Number(process.env.FIREBASE_SIGNED_URL_EXPIRES_SECONDS);
-const FIREBASE_SIGNED_URL_EXPIRES_SECONDS = Number.isFinite(signedUrlExpiresSecondsEnv) && signedUrlExpiresSecondsEnv > 0
-    ? signedUrlExpiresSecondsEnv
-    : 900;
-const PORT = process.env.PORT || 3000;
+const config = readEnv();
 
 module.exports = {
-    LOW_MEMORY_MODE,
-    MAX_FILE_SIZE_MB,
-    MAX_FILE_SIZE,
-    MAX_FILE_SIZE_WAS_CLAMPED,
-    IMAGE_PROCESSOR,
-    RESIZE_CONCURRENCY,
-    RESIZE_CONCURRENCY_WAS_CLAMPED,
-    DEFAULT_RATE_LIMIT_MAX,
-    HEAVY_RATE_LIMIT_MAX,
-    HEAVY_RATE_LIMIT_WAS_CLAMPED,
-    ENABLE_DEBUG_ENDPOINT,
-    UPLOAD_TEMP_CLEANUP_ENABLED,
-    UPLOAD_TEMP_CLEANUP_INTERVAL_SECONDS,
-    UPLOAD_TEMP_STALE_AGE_SECONDS,
-    FIREBASE_STORAGE_BUCKET,
-    FIREBASE_UPLOAD_ACL,
-    FIREBASE_URL_MODE,
-    FIREBASE_SIGNED_URL_EXPIRES_SECONDS,
-    PORT,
+    readEnv,
+    config,
+    LOW_MEMORY_MODE: config.lowMemoryMode,
+    MAX_FILE_SIZE_MB: config.maxFileSizeMb,
+    MAX_FILE_SIZE: config.maxFileSizeBytes,
+    MAX_FILE_SIZE_WAS_CLAMPED: config.maxFileSizeWasClamped,
+    IMAGE_PROCESSOR: config.imageProcessor,
+    RESIZE_CONCURRENCY: config.resizeConcurrency,
+    RESIZE_CONCURRENCY_WAS_CLAMPED: config.resizeConcurrencyWasClamped,
+    DEFAULT_RATE_LIMIT_MAX: config.defaultRateLimitMax,
+    HEAVY_RATE_LIMIT_MAX: config.heavyRateLimitMax,
+    HEAVY_RATE_LIMIT_WAS_CLAMPED: config.heavyRateLimitWasClamped,
+    ENABLE_DEBUG_ENDPOINT: config.enableDebugEndpoint,
+    UPLOAD_TEMP_CLEANUP_ENABLED: config.uploadTempCleanupEnabled,
+    UPLOAD_TEMP_CLEANUP_INTERVAL_SECONDS: config.uploadTempCleanupIntervalSeconds,
+    UPLOAD_TEMP_STALE_AGE_SECONDS: config.uploadTempStaleAgeSeconds,
+    FIREBASE_STORAGE_BUCKET: config.firebaseStorageBucket,
+    FIREBASE_SERVICE_ACCOUNT_PATH: config.firebaseServiceAccountPath,
+    FIREBASE_UPLOAD_ACL: config.firebaseUploadAcl,
+    FIREBASE_URL_MODE: config.firebaseUrlMode,
+    FIREBASE_SIGNED_URL_EXPIRES_SECONDS: config.firebaseSignedUrlExpiresSeconds,
+    PORT: config.port,
 };

--- a/config/firebase.js
+++ b/config/firebase.js
@@ -1,32 +1,68 @@
 const admin = require('firebase-admin');
 
-const { FIREBASE_STORAGE_BUCKET } = require('./env');
+const { FIREBASE_SERVICE_ACCOUNT_PATH, FIREBASE_STORAGE_BUCKET } = require('./env');
 const { log } = require('../utils/logger');
 
-const serviceAccountPath = process.env.FIREBASE_SERVICE_ACCOUNT_PATH;
-if (!serviceAccountPath) {
+if (!FIREBASE_SERVICE_ACCOUNT_PATH) {
     log('error', 'FIREBASE_SERVICE_ACCOUNT_PATH is required and must point to a Firebase service account JSON file.');
     process.exit(1);
 }
 
 let serviceAccount;
 try {
-    serviceAccount = require(serviceAccountPath);
+    serviceAccount = require(FIREBASE_SERVICE_ACCOUNT_PATH);
 } catch (error) {
     log('error', 'Failed to load service account from path', {
-        path: serviceAccountPath,
+        path: FIREBASE_SERVICE_ACCOUNT_PATH,
         error: error.message,
     });
     process.exit(1);
 }
 
 if (!admin.apps.length) {
-    admin.initializeApp({
+    const appConfig = {
         credential: admin.credential.cert(serviceAccount),
-        storageBucket: FIREBASE_STORAGE_BUCKET,
-    });
+    };
+
+    if (FIREBASE_STORAGE_BUCKET) {
+        appConfig.storageBucket = FIREBASE_STORAGE_BUCKET;
+    }
+
+    admin.initializeApp(appConfig);
 }
 
-const bucket = admin.storage().bucket();
+let bucketInstance = null;
 
-module.exports = { admin, bucket };
+const getBucket = () => {
+    if (!FIREBASE_STORAGE_BUCKET) {
+        throw new Error('FIREBASE_STORAGE_BUCKET is required before Firebase Storage bucket access.');
+    }
+
+    if (!bucketInstance) {
+        bucketInstance = admin.storage().bucket(FIREBASE_STORAGE_BUCKET);
+    }
+
+    return bucketInstance;
+};
+
+const bucket = new Proxy({}, {
+    get(_target, property) {
+        const resolvedBucket = getBucket();
+        const value = resolvedBucket[property];
+
+        if (typeof value === 'function') {
+            return value.bind(resolvedBucket);
+        }
+
+        return value;
+    },
+});
+
+const getAuth = () => admin.auth();
+
+module.exports = {
+    admin,
+    bucket,
+    getAuth,
+    getBucket,
+};

--- a/config/providerRegistry.js
+++ b/config/providerRegistry.js
@@ -1,0 +1,24 @@
+const { createFirebaseAuthProvider } = require('../auth/firebaseAuthProvider');
+const { createSqliteImageRepository } = require('../repositories/sqliteImageRepository');
+const { createLocalStorageProvider } = require('../storage/localStorageProvider');
+
+function createProviderRegistry(dependencies = {}) {
+    return {
+        authProviders: {
+            firebase: ({ config }) => createFirebaseAuthProvider({
+                config,
+                firebaseAuth: dependencies.firebaseAuth,
+            }),
+        },
+        imageRepositories: {
+            sqlite: createSqliteImageRepository,
+        },
+        storageProviders: {
+            local: createLocalStorageProvider,
+        },
+    };
+}
+
+module.exports = {
+    createProviderRegistry,
+};

--- a/controllers/imageApiController.js
+++ b/controllers/imageApiController.js
@@ -1,0 +1,250 @@
+const VALIDATION_ERROR = 'VALIDATION_ERROR';
+
+const createValidationError = (message) => {
+    const error = new Error(message);
+    error.statusCode = 400;
+    error.code = VALIDATION_ERROR;
+    return error;
+};
+
+const requireObject = (value, name) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error(`${name} must be an object.`);
+    }
+    return value;
+};
+
+const requireFunction = (value, name) => {
+    if (typeof value !== 'function') {
+        throw new Error(`${name} must be a function.`);
+    }
+};
+
+const parseIntegerQueryParam = (query, name, { allowZero }) => {
+    if (!Object.prototype.hasOwnProperty.call(query, name)) {
+        return undefined;
+    }
+
+    const value = query[name];
+    if (Array.isArray(value) || typeof value === 'boolean') {
+        throw createValidationError(`${name} must be an integer.`);
+    }
+
+    if (typeof value === 'number') {
+        if (!Number.isInteger(value) || value < 0 || (!allowZero && value === 0)) {
+            throw createValidationError(`${name} must be ${allowZero ? 'a non-negative' : 'a positive'} integer.`);
+        }
+        return value;
+    }
+
+    if (typeof value !== 'string' || value.trim() === '' || !/^\d+$/.test(value.trim())) {
+        throw createValidationError(`${name} must be ${allowZero ? 'a non-negative' : 'a positive'} integer.`);
+    }
+
+    const parsedValue = Number(value.trim());
+    if (!Number.isSafeInteger(parsedValue) || parsedValue < 0 || (!allowZero && parsedValue === 0)) {
+        throw createValidationError(`${name} must be ${allowZero ? 'a non-negative' : 'a positive'} integer.`);
+    }
+
+    return parsedValue;
+};
+
+const parsePaginationOptions = (query = {}) => {
+    const options = {};
+    const limit = parseIntegerQueryParam(query, 'limit', { allowZero: false });
+    const offset = parseIntegerQueryParam(query, 'offset', { allowZero: true });
+
+    if (limit !== undefined) {
+        options.limit = limit;
+    }
+    if (offset !== undefined) {
+        options.offset = offset;
+    }
+
+    return options;
+};
+
+const parseBooleanQueryParam = (query, name) => {
+    if (!Object.prototype.hasOwnProperty.call(query, name)) {
+        return undefined;
+    }
+
+    const value = query[name];
+    if (Array.isArray(value) || value === '') {
+        throw createValidationError(`${name} must be true or false.`);
+    }
+
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (value === 'true') {
+        return true;
+    }
+    if (value === 'false') {
+        return false;
+    }
+
+    throw createValidationError(`${name} must be true or false.`);
+};
+
+const parseMyImagesOptions = (query = {}) => {
+    const options = parsePaginationOptions(query);
+    const archived = parseBooleanQueryParam(query, 'archived');
+    const includeArchived = parseBooleanQueryParam(query, 'includeArchived');
+
+    if (archived !== undefined) {
+        options.archived = archived;
+    }
+    if (includeArchived !== undefined) {
+        options.includeArchived = includeArchived;
+    }
+
+    return options;
+};
+
+const requireBooleanBodyField = (body, name) => {
+    if (!body || typeof body !== 'object' || Array.isArray(body) || typeof body[name] !== 'boolean') {
+        throw createValidationError(`${name} must be a boolean.`);
+    }
+
+    return body[name];
+};
+
+const requireImageId = (imageId) => {
+    if (typeof imageId !== 'string' || imageId.trim() === '') {
+        throw createValidationError('imageId is required.');
+    }
+    return imageId;
+};
+
+function createImageApiController({
+    imageService,
+    imageUploadService,
+    authProvider,
+} = {}) {
+    requireObject(imageService, 'imageService');
+    requireObject(imageUploadService, 'imageUploadService');
+    requireObject(authProvider, 'authProvider');
+
+    requireFunction(imageService.listPublicImages, 'imageService.listPublicImages');
+    requireFunction(imageService.listUserImages, 'imageService.listUserImages');
+    requireFunction(imageService.updateImageVisibility, 'imageService.updateImageVisibility');
+    requireFunction(imageService.archiveImage, 'imageService.archiveImage');
+    requireFunction(imageService.unarchiveImage, 'imageService.unarchiveImage');
+    requireFunction(imageService.deleteImage, 'imageService.deleteImage');
+    requireFunction(imageUploadService.uploadImage, 'imageUploadService.uploadImage');
+    requireFunction(authProvider.requireUser, 'authProvider.requireUser');
+
+    const listPublicImages = async (req, res, next) => {
+        try {
+            const options = parsePaginationOptions(req.query || {});
+            const images = await imageService.listPublicImages(options);
+            res.status(200).json({ images });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    const listMyImages = async (req, res, next) => {
+        try {
+            const options = parseMyImagesOptions(req.query || {});
+            const currentUser = await authProvider.requireUser(req);
+            const images = await imageService.listUserImages(currentUser, options);
+            res.status(200).json({ images });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    const updateImageVisibility = async (req, res, next) => {
+        try {
+            const imageId = requireImageId(req.params && req.params.imageId);
+            const currentUser = await authProvider.requireUser(req);
+            const isPublic = requireBooleanBodyField(req.body, 'isPublic');
+            const image = await imageService.updateImageVisibility(imageId, currentUser, isPublic);
+
+            if (!image) {
+                res.status(404).json({ error: 'Image not found' });
+                return;
+            }
+
+            res.status(200).json({ image });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    const archiveImage = async (req, res, next) => {
+        try {
+            const imageId = requireImageId(req.params && req.params.imageId);
+            const currentUser = await authProvider.requireUser(req);
+            const image = await imageService.archiveImage(imageId, currentUser);
+
+            if (!image) {
+                res.status(404).json({ error: 'Image not found' });
+                return;
+            }
+
+            res.status(200).json({ image });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    const unarchiveImage = async (req, res, next) => {
+        try {
+            const imageId = requireImageId(req.params && req.params.imageId);
+            const currentUser = await authProvider.requireUser(req);
+            const image = await imageService.unarchiveImage(imageId, currentUser);
+
+            if (!image) {
+                res.status(404).json({ error: 'Image not found' });
+                return;
+            }
+
+            res.status(200).json({ image });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    const deleteImage = async (req, res, next) => {
+        try {
+            const imageId = requireImageId(req.params && req.params.imageId);
+            const currentUser = await authProvider.requireUser(req);
+            const result = await imageService.deleteImage(imageId, currentUser);
+            res.status(200).json(result);
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    const uploadImage = async (req, res, next) => {
+        try {
+            const currentUser = await authProvider.requireUser(req);
+            const image = await imageUploadService.uploadImage({
+                file: req.file,
+                currentUser,
+                fields: req.body || {},
+            });
+            res.status(201).json({ image });
+        } catch (error) {
+            next(error);
+        }
+    };
+
+    return {
+        listPublicImages,
+        listMyImages,
+        updateImageVisibility,
+        archiveImage,
+        unarchiveImage,
+        deleteImage,
+        uploadImage,
+    };
+}
+
+module.exports = {
+    createImageApiController,
+};

--- a/controllers/imageController.js
+++ b/controllers/imageController.js
@@ -31,12 +31,20 @@ const hasValidImageFile = (req, res, invalidMimetypeMessage = 'Uploaded file is 
 
 const createImageController = ({
     bucket,
+    bucketGetter,
     imageProcessor,
     uploadAcl,
     usePredefinedAcl,
     urlMode,
     signedUrlExpiresSeconds,
 }) => {
+    const getLegacyBucket = () => {
+        if (bucketGetter) {
+            return bucketGetter();
+        }
+        return bucket;
+    };
+
     const resize = async (req, res) => {
         if (!hasValidImageFile(req, res)) return;
 
@@ -85,7 +93,8 @@ const createImageController = ({
             };
             const ext = mimeToExt[mime] || 'bin';
             const fileName = `images/${uuid()}.${ext}`;
-            const file = bucket.file(fileName);
+            const legacyBucket = getLegacyBucket();
+            const file = legacyBucket.file(fileName);
 
             await pipeline(
                 fs.createReadStream(req.file.path),
@@ -101,7 +110,7 @@ const createImageController = ({
 
             const url = await resolveStorageUrl({
                 file,
-                bucketName: bucket.name,
+                bucketName: legacyBucket.name,
                 fileName,
                 urlMode,
                 signedUrlExpiresSeconds,
@@ -125,7 +134,8 @@ const createImageController = ({
             const fileName = `images/${uuid()}.jpg`;
             log('info', 'Uploading resized image', { fileName });
 
-            const file = bucket.file(fileName);
+            const legacyBucket = getLegacyBucket();
+            const file = legacyBucket.file(fileName);
 
             if (imageProcessor === 'jimp') {
                 const Jimp = getJimp();
@@ -161,7 +171,7 @@ const createImageController = ({
 
             const url = await resolveStorageUrl({
                 file,
-                bucketName: bucket.name,
+                bucketName: legacyBucket.name,
                 fileName,
                 urlMode,
                 signedUrlExpiresSeconds,
@@ -187,7 +197,8 @@ const createImageController = ({
                 return res.status(400).send('Image name is required');
             }
 
-            const file = bucket.file(`images/${imgName}`);
+            const legacyBucket = getLegacyBucket();
+            const file = legacyBucket.file(`images/${imgName}`);
             await file.delete();
             log('info', 'File deleted from Firebase Storage', { imgName });
 

--- a/docs/backend-mvp-validation.md
+++ b/docs/backend-mvp-validation.md
@@ -1,0 +1,135 @@
+# Backend MVP Validation
+
+Slice 18A validation target:
+
+```env
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+```
+
+Canonical provider-backed routes:
+
+```text
+GET    /images/public
+GET    /images/me
+POST   /images
+DELETE /images/:imageId
+PATCH  /images/:imageId/visibility
+POST   /images/:imageId/archive
+POST   /images/:imageId/unarchive
+GET    /media/*
+```
+
+Legacy routes remain available:
+
+```text
+/health
+/resize
+/upload
+/resize-upload
+/delete-image
+```
+
+## Validation Findings
+
+- Provider selection remains centralized in `config/env.js`, `config/container.js`, and `config/providerRegistry.js`.
+- Controllers, routes, and services do not import concrete SQLite, local storage, or Firebase provider implementations.
+- `storageKey` and `thumbnailKey` stay internal; frontend DTOs are created by `services/imagePresenter.js`.
+- Local storage validates keys before resolving paths and verifies object paths stay inside `LOCAL_STORAGE_ROOT`.
+- `/media` is mounted only when `container.config.storageProvider === 'local'`.
+- `/images` routes are additive and do not replace legacy routes.
+- Upload cleanup is covered by `tests/imageUploadService.test.js`.
+- SQLite repository exposes `close()` and registry/container tests close it after use.
+- Firebase Auth provider tests inject fake Firebase Auth and do not require real credentials.
+- `better-sqlite3` is present in `package.json` and `package-lock.json`; `npm install --package-lock-only --ignore-scripts` reports the lockfile is up to date.
+
+## Automated Checks
+
+```bash
+npm install
+npm test
+node --check index.js
+node --check app.js
+```
+
+## Local MVP Startup
+
+```bash
+AUTH_PROVIDER=firebase \
+DATABASE_PROVIDER=sqlite \
+STORAGE_PROVIDER=local \
+SQLITE_PATH=./data/photogram.sqlite \
+LOCAL_STORAGE_ROOT=./data/images \
+PUBLIC_MEDIA_BASE_URL=http://localhost:3000/media \
+FIREBASE_SERVICE_ACCOUNT_PATH=/secure/photogram/firebase-service-account.json \
+LOW_MEMORY_MODE=true \
+MAX_FILE_SIZE_MB=5 \
+RESIZE_CONCURRENCY=1 \
+HEAVY_RATE_LIMIT_MAX=8 \
+ENABLE_DEBUG_ENDPOINT=false \
+IMAGE_PROCESSOR=sharp \
+npm start
+```
+
+## Manual Curl Checks
+
+```bash
+curl http://localhost:3000/health
+
+curl http://localhost:3000/images/public
+
+curl -H "Authorization: Bearer <firebase-id-token>" \
+  http://localhost:3000/images/me
+
+curl -X POST \
+  -H "Authorization: Bearer <firebase-id-token>" \
+  -F "image=@/path/to/photo.jpg" \
+  -F "description=Provider-backed upload" \
+  -F "isPublic=true" \
+  http://localhost:3000/images
+
+curl -X DELETE \
+  -H "Authorization: Bearer <firebase-id-token>" \
+  http://localhost:3000/images/<image-id>
+
+curl -X PATCH \
+  -H "Authorization: Bearer <firebase-id-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"isPublic":false}' \
+  http://localhost:3000/images/<image-id>/visibility
+
+curl -X POST \
+  -H "Authorization: Bearer <firebase-id-token>" \
+  http://localhost:3000/images/<image-id>/archive
+
+curl -X POST \
+  -H "Authorization: Bearer <firebase-id-token>" \
+  http://localhost:3000/images/<image-id>/unarchive
+
+curl -H "Authorization: Bearer <firebase-id-token>" \
+  http://localhost:3000/images/me?archived=true
+
+curl http://localhost:3000/media/users/<uid>/images/<image-id>.jpg
+```
+
+Legacy upload check:
+
+```bash
+curl -X POST \
+  -F "image=@/path/to/photo.jpg" \
+  http://localhost:3000/resize-upload
+```
+
+Upload edge cases to validate manually:
+
+- valid image
+- non-image file
+- empty payload
+- oversize payload using `MAX_FILE_SIZE_MB`
+
+## NC110 Risks
+
+- `sharp` may fail on Atom-era CPUs; switch to `IMAGE_PROCESSOR=jimp` if the server logs invalid opcode or native module failures.
+- Express `/media` serving is acceptable for low traffic but Nginx/Caddy static serving may be more efficient later.
+- SQLite and image directory backups must be managed together.

--- a/docs/photogram-mvp-implementation-plan.md
+++ b/docs/photogram-mvp-implementation-plan.md
@@ -1,0 +1,1516 @@
+# Photogram Provider-Agnostic MVP Implementation Plan
+
+Status: Draft v1
+Audience: Codex, project maintainer
+Related document: `docs/photogram-provider-agnostic-system-spec.md`
+
+---
+
+## 1. Purpose
+
+This document defines the smallest safe implementation plan for moving Photogram toward a provider-agnostic architecture.
+
+The system specification defines the target architecture. This MVP plan defines the practical order of code changes needed to make the app work with local self-hosted services while preserving existing user-facing behavior.
+
+The MVP is not a full Firebase replacement. It is the first working provider-agnostic slice.
+
+---
+
+## 2. MVP Goal
+
+The MVP goal is:
+
+```text
+Photogram can run with Firebase Auth, SQLite metadata, and local filesystem image storage while the frontend remains source-agnostic and talks only to the Photogram backend API for gallery/upload/delete flows.
+```
+
+The intended MVP provider configuration is:
+
+```env
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+```
+
+This avoids rewriting authentication first. Firebase Auth may remain during the MVP, but Firestore and Firebase Storage should no longer be required for the main gallery/upload/delete flow in local mode.
+
+---
+
+## 3. MVP Non-Goals
+
+The following are intentionally outside the MVP:
+
+1. Local username/password authentication.
+2. Full account registration and password reset flows.
+3. MinIO, PostgreSQL, Redis, Docker Compose, or background workers.
+4. Public/private media optimization through Nginx `X-Accel-Redirect`.
+5. Complex pagination, albums, tagging, search, comments, or sharing.
+6. Admin dashboards.
+7. Full historical data migration from Firestore unless explicitly added later.
+8. Removing Firebase SDK usage from login/bootstrap before local auth exists.
+9. Perfect Firebase/local feature parity.
+10. A generalized plugin system that loads arbitrary provider modules from `.env`.
+
+---
+
+## 4. MVP Success Criteria
+
+The MVP is successful when:
+
+1. Backend provider selection happens once at startup through config/container code.
+2. Controllers and services do not branch on provider names.
+3. `.env` can select:
+
+    ```env
+    AUTH_PROVIDER=firebase
+    DATABASE_PROVIDER=sqlite
+    STORAGE_PROVIDER=local
+    ```
+
+4. Backend upload stores processed images on local disk.
+5. Backend upload stores image metadata in SQLite.
+6. Backend delete removes local image files and SQLite metadata.
+7. Backend gallery endpoints return normalized image DTOs.
+8. Frontend public gallery uses backend `GET /images/public`.
+9. Frontend user gallery uses backend `GET /images/me`.
+10. Frontend upload/delete flows call backend API wrappers only.
+11. Frontend gallery/upload/delete flows do not directly use Firestore or Firebase Storage.
+12. Existing compatibility endpoints still work where practical:
+
+    ```text
+    POST /resize-upload
+    POST /delete-image
+    ```
+
+13. Automated backend tests cover provider config, local storage, SQLite repository, and image service behavior.
+14. Frontend tests cover gallery rendering from backend API responses and upload/delete API calls.
+15. The backend remains safe for the Samsung NC110 low-memory deployment profile.
+
+---
+
+## 5. Final MVP Architecture
+
+```text
+React frontend
+  |
+  | Photogram API
+  v
+Express backend
+  |
+  |-- AuthProvider=firebase
+  |-- ImageRepository=sqlite
+  |-- StorageProvider=local
+  |-- ImageProcessor=sharp|jimp
+  |
+  v
+Firebase Auth + SQLite DB + local filesystem
+```
+
+The frontend should not know whether image metadata comes from Firestore or SQLite. It should not know whether image files come from Firebase Storage or local disk.
+
+---
+
+## 6. Required Environment Variables
+
+### 6.1 Backend Local MVP
+
+```env
+NODE_ENV=development
+PORT=3000
+
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+
+SQLITE_PATH=./data/photogram.sqlite
+LOCAL_STORAGE_ROOT=./data/images
+PUBLIC_MEDIA_BASE_URL=http://localhost:3000/media
+
+FIREBASE_SERVICE_ACCOUNT_PATH=/secure/photogram/firebase-service-account.json
+
+LOW_MEMORY_MODE=true
+MAX_FILE_SIZE_MB=5
+RESIZE_CONCURRENCY=1
+HEAVY_RATE_LIMIT_MAX=8
+ENABLE_DEBUG_ENDPOINT=false
+IMAGE_PROCESSOR=sharp
+```
+
+### 6.2 Backend NC110 Production MVP
+
+```env
+NODE_ENV=production
+PORT=3000
+
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+
+SQLITE_PATH=/var/lib/photogram/photogram.sqlite
+LOCAL_STORAGE_ROOT=/var/lib/photogram/images
+PUBLIC_MEDIA_BASE_URL=https://photos.example.com/media
+
+FIREBASE_SERVICE_ACCOUNT_PATH=/secure/photogram/firebase-service-account.json
+
+LOW_MEMORY_MODE=true
+MAX_FILE_SIZE_MB=5
+RESIZE_CONCURRENCY=1
+HEAVY_RATE_LIMIT_MAX=8
+ENABLE_DEBUG_ENDPOINT=false
+IMAGE_PROCESSOR=sharp
+```
+
+If `sharp` is unstable on the Samsung NC110, switch to:
+
+```env
+IMAGE_PROCESSOR=jimp
+```
+
+### 6.3 Frontend MVP
+
+```env
+REACT_APP_API_URL=http://localhost:3000
+REACT_APP_AUTH_PROVIDER=firebase
+```
+
+The frontend can keep Firebase Auth config during the MVP, but gallery/upload/delete should go through backend API clients.
+
+---
+
+## 7. Canonical MVP API Contract
+
+### 7.1 Health
+
+```text
+GET /health
+```
+
+Response:
+
+```json
+{
+    "ok": true
+}
+```
+
+### 7.2 Public Images
+
+```text
+GET /images/public
+```
+
+Response:
+
+```json
+{
+    "images": [
+        {
+            "id": "img_123",
+            "ownerId": "uid_123",
+            "title": "Example",
+            "description": "",
+            "imageUrl": "http://localhost:3000/media/users/uid_123/images/img_123.webp",
+            "thumbnailUrl": "http://localhost:3000/media/users/uid_123/thumbnails/img_123.webp",
+            "width": 1280,
+            "height": 720,
+            "sizeBytes": 123456,
+            "mimeType": "image/webp",
+            "isPublic": true,
+            "createdAt": "2026-06-22T00:00:00.000Z",
+            "updatedAt": "2026-06-22T00:00:00.000Z"
+        }
+    ]
+}
+```
+
+### 7.3 My Images
+
+```text
+GET /images/me
+Authorization: Bearer <firebase-id-token>
+```
+
+Response:
+
+```json
+{
+    "images": []
+}
+```
+
+### 7.4 Upload Image
+
+```text
+POST /images
+Authorization: Bearer <firebase-id-token>
+Content-Type: multipart/form-data
+```
+
+Form fields:
+
+```text
+image: File
+isPublic: true|false
+caption: optional string
+```
+
+Response:
+
+```json
+{
+    "image": {
+        "id": "img_123",
+        "ownerId": "uid_123",
+        "imageUrl": "http://localhost:3000/media/users/uid_123/images/img_123.webp",
+        "thumbnailUrl": "http://localhost:3000/media/users/uid_123/thumbnails/img_123.webp",
+        "isPublic": true,
+        "createdAt": "2026-06-22T00:00:00.000Z"
+    }
+}
+```
+
+### 7.5 Delete Image
+
+```text
+DELETE /images/:imageId
+Authorization: Bearer <firebase-id-token>
+```
+
+Response:
+
+```json
+{
+    "ok": true
+}
+```
+
+### 7.6 Compatibility Endpoint: Upload
+
+```text
+POST /resize-upload
+Authorization: Bearer <firebase-id-token>
+Content-Type: multipart/form-data
+```
+
+This should call the same backend service used by `POST /images`.
+
+### 7.7 Compatibility Endpoint: Delete
+
+```text
+POST /delete-image
+Authorization: Bearer <firebase-id-token>
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+    "imageId": "img_123"
+}
+```
+
+This should call the same backend service used by `DELETE /images/:imageId`.
+
+---
+
+## 8. Normalized Image DTO
+
+The backend should return this frontend-facing shape regardless of provider:
+
+```ts
+type PhotogramImage = {
+    id: string;
+    ownerId?: string;
+    title?: string;
+    description?: string;
+    imageUrl: string;
+    thumbnailUrl?: string;
+    width?: number;
+    height?: number;
+    sizeBytes?: number;
+    mimeType?: string;
+    isPublic: boolean;
+    createdAt: string;
+    updatedAt?: string;
+};
+```
+
+Provider-specific fields such as `storageKey`, `thumbnailKey`, Firebase bucket names, filesystem paths, and signed URL internals must not be required by frontend components.
+
+The database should store storage keys, not provider-specific permanent URLs.
+
+---
+
+## 9. SQLite MVP Schema
+
+Use a small SQLite schema first.
+
+```sql
+CREATE TABLE IF NOT EXISTS images (
+    id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    title TEXT,
+    description TEXT,
+    storage_key TEXT NOT NULL,
+    thumbnail_key TEXT,
+    width INTEGER,
+    height INTEGER,
+    size_bytes INTEGER,
+    mime_type TEXT,
+    is_public INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_images_public_created_at
+ON images (is_public, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_images_owner_created_at
+ON images (owner_id, created_at DESC);
+```
+
+MVP delete behavior:
+
+```text
+Hard delete files from local storage.
+Hard delete or soft delete DB row based on easiest compatibility with current UI.
+Preferred initial implementation: soft delete DB row using deleted_at, then exclude deleted rows from list queries.
+```
+
+---
+
+## 10. Local Storage Layout
+
+Suggested local development layout:
+
+```text
+./data/
+  photogram.sqlite
+  images/
+    users/
+      <ownerId>/
+        images/
+          <imageId>.webp
+        thumbnails/
+          <imageId>.webp
+```
+
+Suggested production layout:
+
+```text
+/var/lib/photogram/
+  photogram.sqlite
+  images/
+    users/
+      <ownerId>/
+        images/
+          <imageId>.webp
+        thumbnails/
+          <imageId>.webp
+```
+
+Storage keys should be relative paths such as:
+
+```text
+users/<ownerId>/images/<imageId>.webp
+users/<ownerId>/thumbnails/<imageId>.webp
+```
+
+The local storage provider must reject path traversal attempts such as:
+
+```text
+../secret.txt
+users/../../secret.txt
+/path/outside/root.jpg
+```
+
+---
+
+## 11. Implementation Slices
+
+Each slice should be small enough for one Codex task or one focused commit.
+
+---
+
+### Slice 0: Baseline Audit
+
+Goal: establish the current behavior before refactoring.
+
+Tasks:
+
+1. Identify current backend upload/delete routes and Firebase calls.
+2. Identify current frontend Firestore and Firebase Storage usage in gallery/upload/delete flows.
+3. Record current manual test commands.
+4. Record current env variables.
+
+Expected output:
+
+```text
+A short note in the PR or commit message listing current files touched by Firebase gallery/storage logic.
+```
+
+Acceptance checks:
+
+```bash
+# Backend
+npm test
+npm start
+
+# Frontend
+yarn test
+yarn build
+```
+
+Manual checks:
+
+```text
+/login works.
+/ public gallery still renders with current provider.
+/upload still submits with current provider.
+/mygallery still renders with current provider.
+```
+
+---
+
+### Slice 1: Backend Env Parsing
+
+Goal: parse and validate provider-related env values in one place.
+
+Files likely added/changed:
+
+```text
+config/env.js
+tests/env.test.js
+index.js
+```
+
+Tasks:
+
+1. Add `readEnv()`.
+2. Parse provider values:
+
+    ```text
+    AUTH_PROVIDER
+    DATABASE_PROVIDER
+    STORAGE_PROVIDER
+    ```
+
+3. Parse local provider values:
+
+    ```text
+    SQLITE_PATH
+    LOCAL_STORAGE_ROOT
+    PUBLIC_MEDIA_BASE_URL
+    ```
+
+4. Parse Firebase values:
+
+    ```text
+    FIREBASE_SERVICE_ACCOUNT_PATH
+    FIREBASE_STORAGE_BUCKET
+    FIREBASE_URL_MODE
+    FIREBASE_SIGNED_URL_EXPIRES_SECONDS
+    ```
+
+5. Parse low-memory values:
+
+    ```text
+    LOW_MEMORY_MODE
+    MAX_FILE_SIZE_MB
+    RESIZE_CONCURRENCY
+    HEAVY_RATE_LIMIT_MAX
+    ENABLE_DEBUG_ENDPOINT
+    IMAGE_PROCESSOR
+    ```
+
+6. Validate allowed provider names.
+7. Fail fast on invalid provider combinations or missing required values.
+8. Add unit tests.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/env.test.js
+```
+
+Required tests:
+
+```text
+- defaults to firebase/sqlite/local only if intentionally configured that way
+- invalid AUTH_PROVIDER fails
+- invalid DATABASE_PROVIDER fails
+- invalid STORAGE_PROVIDER fails
+- sqlite requires SQLITE_PATH
+- local storage requires LOCAL_STORAGE_ROOT
+- firebase provider requires FIREBASE_SERVICE_ACCOUNT_PATH
+- numeric values are parsed once and validated
+```
+
+---
+
+### Slice 2: Backend Provider Container
+
+Goal: centralize provider creation and dependency injection.
+
+Files likely added/changed:
+
+```text
+config/container.js
+app.js
+index.js
+tests/container.test.js
+```
+
+Tasks:
+
+1. Add provider registries:
+
+    ```js
+    const authProviders = {};
+    const imageRepositories = {};
+    const storageProviders = {};
+    ```
+
+2. Add `resolveProvider(registry, providerName, providerType)`.
+3. Add `createContainer(config)`.
+4. Update `index.js` so startup becomes:
+
+    ```js
+    const config = readEnv();
+    const container = createContainer(config);
+    const app = createApp(container);
+    ```
+
+5. Update `app.js` so it receives `container`.
+6. Add tests with fake providers to prove injection works.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/container.test.js
+npm start
+```
+
+Required tests:
+
+```text
+- resolves known provider names
+- rejects unsupported provider names
+- creates auth provider
+- creates image repository
+- creates storage provider
+- passes dependencies into image service factory
+```
+
+Important rule:
+
+```text
+No controller or service should read process.env directly for provider selection.
+```
+
+---
+
+### Slice 3: Local Storage Provider
+
+Goal: save, URL-resolve, and delete processed image files on local disk.
+
+Files likely added/changed:
+
+```text
+storage/localStorageProvider.js
+tests/localStorageProvider.test.js
+```
+
+Provider contract:
+
+```js
+function createStorageProvider(config) {
+    async function saveObject(input) {}
+    async function deleteObject(storageKey) {}
+    async function getUrl(storageKey, options) {}
+
+    return {
+        saveObject,
+        deleteObject,
+        getUrl
+    };
+}
+```
+
+Tasks:
+
+1. Create directories as needed.
+2. Save processed image files under `LOCAL_STORAGE_ROOT`.
+3. Return public URLs using `PUBLIC_MEDIA_BASE_URL`.
+4. Reject path traversal.
+5. Make delete idempotent where practical.
+6. Avoid unnecessary large buffers where current image processor allows.
+7. Add tests using temporary directories.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/localStorageProvider.test.js
+```
+
+Required tests:
+
+```text
+- saves object under root
+- returns URL based on PUBLIC_MEDIA_BASE_URL
+- deletes object
+- deleting missing object does not crash, if selected behavior is idempotent
+- rejects ../ traversal
+- rejects absolute paths outside root
+```
+
+---
+
+### Slice 4: SQLite Image Repository
+
+Goal: store and query image metadata locally.
+
+Files likely added/changed:
+
+```text
+repositories/sqliteImageRepository.js
+tests/sqliteImageRepository.test.js
+package.json
+package-lock.json
+```
+
+Tasks:
+
+1. Choose lightweight SQLite dependency.
+2. Initialize schema on repository creation or with an explicit `init()` called at startup.
+3. Implement:
+
+    ```js
+    listPublicImages(options)
+    listImagesByOwner(ownerId, options)
+    findImageById(imageId)
+    createImage(imageData)
+    markImageDeleted(imageId, ownerId)
+    deleteImageById(imageId, ownerId)
+    ```
+
+4. Exclude soft-deleted rows from list queries.
+5. Order gallery queries by newest first.
+6. Add tests using temporary SQLite DB files or in-memory DB where supported.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/sqliteImageRepository.test.js
+```
+
+Required tests:
+
+```text
+- creates schema
+- inserts image metadata
+- lists public images newest first
+- lists images by owner newest first
+- finds image by id
+- excludes deleted images
+- delete is owner-scoped
+```
+
+NC110 note:
+
+```text
+Prefer a dependency and access pattern that does not add a long-running database daemon.
+```
+
+---
+
+### Slice 5: Image Presenter / DTO Mapper
+
+Goal: convert repository records into frontend-safe `PhotogramImage` DTOs.
+
+Files likely added/changed:
+
+```text
+services/imagePresenter.js
+tests/imagePresenter.test.js
+```
+
+Tasks:
+
+1. Map database snake_case fields to frontend camelCase fields.
+2. Call `storageProvider.getUrl(storageKey)` for `imageUrl`.
+3. Call `storageProvider.getUrl(thumbnailKey)` for `thumbnailUrl` when present.
+4. Hide provider internals from frontend DTOs.
+5. Add tests with fake storage provider.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/imagePresenter.test.js
+```
+
+Required tests:
+
+```text
+- maps image row to PhotogramImage DTO
+- generates imageUrl from storage provider
+- generates thumbnailUrl from storage provider
+- does not expose storageKey by default
+```
+
+---
+
+### Slice 6: Image Service
+
+Goal: centralize upload/list/delete business logic behind provider contracts.
+
+Files likely added/changed:
+
+```text
+services/imageService.js
+tests/imageService.test.js
+```
+
+Tasks:
+
+1. Implement public list flow:
+
+    ```js
+    listPublicImages(options)
+    ```
+
+2. Implement user list flow:
+
+    ```js
+    listImagesForUser(userId, options)
+    ```
+
+3. Implement upload flow:
+
+    ```js
+    createImageForUser(user, uploadInput)
+    ```
+
+4. Implement delete flow:
+
+    ```js
+    deleteImageForUser(user, imageId)
+    ```
+
+5. Ensure upload sequence is safe:
+
+    ```text
+    validate input
+    process image
+    save image file
+    save thumbnail file
+    create metadata
+    return DTO
+    ```
+
+6. Ensure delete sequence is safe:
+
+    ```text
+    load metadata
+    check ownership
+    delete image file
+    delete thumbnail file
+    mark/delete metadata
+    return ok
+    ```
+
+7. Add cleanup behavior when storage succeeds but metadata fails.
+8. Add tests using fake repository/storage/image processor.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/imageService.test.js
+```
+
+Required tests:
+
+```text
+- lists public images
+- lists owner images
+- creates image metadata after storage save
+- returns normalized DTO
+- deletes image only for owner
+- rejects delete for non-owner
+- cleans up storage if metadata creation fails
+- handles missing image with clear error
+```
+
+---
+
+### Slice 7: Firebase Auth Provider for MVP
+
+Goal: keep existing login behavior but let the backend authorize authenticated routes.
+
+Files likely added/changed:
+
+```text
+auth/firebaseAuthProvider.js
+config/firebase.js
+tests/firebaseAuthProvider.test.js
+```
+
+Provider contract:
+
+```js
+function createAuthProvider(config) {
+    async function getCurrentUser(req) {}
+    async function requireUser(req) {}
+
+    return {
+        getCurrentUser,
+        requireUser
+    };
+}
+```
+
+Tasks:
+
+1. Read Firebase ID token from:
+
+    ```text
+    Authorization: Bearer <token>
+    ```
+
+2. Validate token with Firebase Admin SDK.
+3. Return normalized user shape:
+
+    ```js
+    {
+        id: decodedToken.uid,
+        email: decodedToken.email || null,
+        provider: 'firebase'
+    }
+    ```
+
+4. Return `401` through controller/middleware when auth is required and missing/invalid.
+5. Keep service account path outside the repository.
+6. Add tests with mocked Firebase Admin verification.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/firebaseAuthProvider.test.js
+```
+
+Required tests:
+
+```text
+- extracts bearer token
+- rejects missing token on requireUser
+- normalizes decoded Firebase token
+- handles Firebase verification failure
+```
+
+---
+
+### Slice 8: Backend HTTP Routes
+
+Goal: expose canonical image routes and preserve compatibility endpoints.
+
+Files likely added/changed:
+
+```text
+controllers/imageController.js
+routes/imageRoutes.js
+routes/systemRoutes.js
+app.js
+tests/imageRoutes.test.js
+```
+
+Canonical routes:
+
+```text
+GET    /images/public
+GET    /images/me
+POST   /images
+DELETE /images/:imageId
+```
+
+Compatibility routes:
+
+```text
+POST   /resize-upload
+POST   /delete-image
+```
+
+Tasks:
+
+1. Wire controllers to `container.imageService`.
+2. Use `container.authProvider` for protected routes.
+3. Keep endpoint paths lowercase and hyphenated for compatibility endpoints.
+4. Return normalized JSON responses.
+5. Add route tests with fake service/auth providers.
+6. Keep existing upload size/rate-limit middleware.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/imageRoutes.test.js
+npm test
+```
+
+Manual checks:
+
+```bash
+curl http://localhost:3000/health
+curl http://localhost:3000/images/public
+```
+
+Upload/delete manual checks should be completed after frontend token handling is wired.
+
+---
+
+### Slice 9: Static Media Serving for Local Public Files
+
+Goal: allow local public image URLs to resolve in development and simple production deployments.
+
+Files likely added/changed:
+
+```text
+app.js
+middleware/staticMedia.js
+tests/staticMedia.test.js
+```
+
+Tasks:
+
+1. Serve `/media/*` from `LOCAL_STORAGE_ROOT` only when `STORAGE_PROVIDER=local`.
+2. Ensure path traversal is not possible.
+3. Do not expose private files if private visibility is implemented separately.
+4. Document that Nginx/Caddy static serving may replace Express static serving later.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/staticMedia.test.js
+```
+
+Manual checks:
+
+```text
+Uploaded public image URL opens in browser.
+Thumbnail URL opens in browser.
+```
+
+---
+
+### Slice 10: Frontend Image API Wrapper
+
+Goal: make the frontend call the Photogram API instead of Firebase/Firestore for gallery/upload/delete.
+
+Files likely added/changed:
+
+```text
+src/api/images.ts
+src/config.ts
+src/api/images.test.ts
+```
+
+Tasks:
+
+1. Ensure `REACT_APP_API_URL` is the only backend URL source.
+2. Implement:
+
+    ```ts
+    getPublicImages()
+    getMyImages(token?: string)
+    uploadImage(input)
+    deleteImage(imageId, token?: string)
+    ```
+
+3. Normalize backend responses.
+4. Keep API functions small and testable.
+5. Keep Firebase Auth token acquisition outside the image API when practical.
+
+Acceptance checks:
+
+```bash
+yarn test src/api/images.test.ts
+```
+
+Required tests:
+
+```text
+- getPublicImages calls /images/public
+- getMyImages calls /images/me with auth header when token provided
+- uploadImage posts multipart data
+- deleteImage calls DELETE /images/:imageId
+- handles non-ok response with useful error
+```
+
+---
+
+### Slice 11: Frontend Gallery Migration
+
+Goal: public and user galleries render backend DTOs.
+
+Files likely added/changed:
+
+```text
+src/components/Gallery/*
+src/state/*
+src/api/images.ts
+```
+
+Tasks:
+
+1. Replace direct Firestore gallery reads with `getPublicImages()`.
+2. Replace direct Firestore user gallery reads with `getMyImages()`.
+3. Keep React components rendering `PhotogramImage` DTOs.
+4. Ensure loading/error/empty states still work.
+5. Add or update colocated tests.
+
+Acceptance checks:
+
+```bash
+yarn test
+yarn build
+```
+
+Manual checks:
+
+```text
+/ renders public images from backend API.
+/mygallery renders current user's images from backend API.
+Empty gallery state still renders correctly.
+API error state does not crash app.
+```
+
+---
+
+### Slice 12: Frontend Upload/Delete Migration
+
+Goal: upload and delete use backend image API functions only.
+
+Files likely added/changed:
+
+```text
+src/components/Upload/*
+src/components/Gallery/*
+src/state/*
+src/api/images.ts
+```
+
+Tasks:
+
+1. Change upload flow to call backend API wrapper.
+2. Change delete flow to call backend API wrapper.
+3. Ensure authenticated requests include Firebase ID token during MVP.
+4. Update Redux action creators/thunks if upload/delete logic lives there.
+5. Remove or isolate Firebase Storage calls from upload/delete flows.
+6. Add/update tests.
+
+Acceptance checks:
+
+```bash
+yarn test
+yarn build
+```
+
+Manual checks:
+
+```text
+Login works.
+Upload image works.
+Uploaded image appears in /mygallery.
+Public image appears in / when isPublic=true.
+Delete image removes it from /mygallery and backend storage.
+Delete failure shows useful UI feedback.
+```
+
+---
+
+### Slice 13: End-to-End Local MVP Validation
+
+Goal: prove the local MVP mode works end-to-end.
+
+Backend env:
+
+```env
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+```
+
+Validation commands:
+
+```bash
+# Backend
+npm test
+npm start
+
+# Frontend
+yarn test
+yarn build
+yarn start
+```
+
+Manual backend checks:
+
+```bash
+curl http://localhost:3000/health
+curl http://localhost:3000/images/public
+```
+
+Manual browser checks:
+
+```text
+1. Open frontend.
+2. Login with Firebase Auth.
+3. Open /upload.
+4. Upload valid image.
+5. Confirm image file exists under LOCAL_STORAGE_ROOT.
+6. Confirm SQLite row exists.
+7. Open /mygallery.
+8. Confirm uploaded image appears.
+9. Open /.
+10. Confirm public image appears if public.
+11. Delete image.
+12. Confirm image is removed from UI.
+13. Confirm file is deleted or no longer reachable.
+14. Confirm SQLite row is deleted or soft-deleted.
+```
+
+Upload safety checks:
+
+```text
+- valid image
+- non-image file
+- empty payload
+- oversize payload based on MAX_FILE_SIZE_MB
+- unauthenticated upload
+- unauthenticated delete
+```
+
+---
+
+### Slice 14: NC110 Deployment Check
+
+Goal: verify the MVP mode on the target low-resource server.
+
+Tasks:
+
+1. Create production directories:
+
+    ```bash
+    sudo mkdir -p /var/lib/photogram/images
+    sudo mkdir -p /var/backups/photogram
+    ```
+
+2. Set ownership to the backend process user.
+3. Deploy backend `.env` outside source control.
+4. Start or reload PM2 process.
+5. Validate logs and memory usage.
+6. Test upload/delete with small image files first.
+7. Validate `sharp`; switch to `jimp` if needed.
+8. Document PM2 command and current env assumptions.
+
+Validation commands:
+
+```bash
+pm2 status
+pm2 logs photogram-backend
+curl http://localhost:3000/health
+```
+
+Operational checks:
+
+```text
+- memory does not grow unexpectedly across repeated uploads
+- upload concurrency remains low
+- oversized files are rejected early
+- debug endpoint remains disabled in production
+- SQLite file and image directory are included in backup plan
+```
+
+---
+
+## 12. Recommended Commit Order
+
+Use small commits with Conventional Commit-style prefixes.
+
+```text
+feat: add provider env parsing
+feat: add backend provider container
+feat: add local storage provider
+feat: add sqlite image repository
+feat: add image DTO presenter
+feat: add provider-backed image service
+feat: add firebase auth provider
+feat: add canonical image routes
+feat: serve local media files
+feat: migrate frontend image API client
+feat: migrate gallery reads to backend API
+feat: migrate upload delete flows to backend API
+fix: validate local MVP mode end to end
+```
+
+Prefer one slice per PR or one small group of tightly related slices.
+
+---
+
+## 13. Codex Task Prompts
+
+Use these prompts one at a time.
+
+### Prompt 1
+
+```text
+Read docs/photogram-provider-agnostic-system-spec.md and docs/photogram-mvp-implementation-plan.md. Implement Slice 1 only: backend env parsing and validation. Keep CommonJS style, 4-space indentation, semicolons, and add node:test coverage under tests/env.test.js. Do not change controllers or route behavior.
+```
+
+### Prompt 2
+
+```text
+Implement Slice 2 only: backend provider container. Add config/container.js with safe provider registries and tests. Update index.js/app.js only as needed for dependency injection. Do not implement SQLite or local storage yet; use existing providers or small placeholders where necessary.
+```
+
+### Prompt 3
+
+```text
+Implement Slice 3 only: local storage provider. Add storage/localStorageProvider.js and tests using temporary directories. It must reject path traversal, save files under LOCAL_STORAGE_ROOT, delete objects, and generate URLs from PUBLIC_MEDIA_BASE_URL.
+```
+
+### Prompt 4
+
+```text
+Implement Slice 4 only: SQLite image repository. Add schema initialization, list/create/find/delete methods, and node:test coverage. Keep dependencies lightweight for the Samsung NC110.
+```
+
+### Prompt 5
+
+```text
+Implement Slices 5 and 6 only: image presenter and image service. Use injected repository/storage/auth/image processor dependencies. Add tests with fake providers. Do not make controllers branch on provider names.
+```
+
+### Prompt 6
+
+```text
+Implement Slices 7 and 8 only: Firebase Auth provider and canonical image routes. Preserve compatibility endpoints /resize-upload and /delete-image by routing them through the same image service. Add route/auth tests.
+```
+
+### Prompt 7
+
+```text
+Implement Slice 10 only: frontend image API wrapper. Use REACT_APP_API_URL, TypeScript types, and tests. Do not change gallery components yet.
+```
+
+### Prompt 8
+
+```text
+Implement Slice 11 only: migrate public and user gallery reads to the backend image API. Remove or isolate direct Firestore reads from gallery flows. Add/update React Testing Library tests.
+```
+
+### Prompt 9
+
+```text
+Implement Slice 12 only: migrate upload and delete flows to backend API wrappers. Authenticated requests should use the current Firebase ID token during the MVP. Add/update tests and keep UI behavior unchanged.
+```
+
+### Prompt 10
+
+```text
+Run the MVP validation checklist from docs/photogram-mvp-implementation-plan.md. Fix only issues directly required for AUTH_PROVIDER=firebase, DATABASE_PROVIDER=sqlite, STORAGE_PROVIDER=local mode to pass upload, list, and delete.
+```
+
+---
+
+## 14. Backend Testing Matrix
+
+| Area | Required command | Required coverage |
+|---|---|---|
+| Env parsing | `npm test -- tests/env.test.js` | provider names, required env, numeric values |
+| Container | `npm test -- tests/container.test.js` | safe registry, provider injection |
+| Local storage | `npm test -- tests/localStorageProvider.test.js` | save, delete, URL, traversal rejection |
+| SQLite repository | `npm test -- tests/sqliteImageRepository.test.js` | schema, create, list, find, delete |
+| DTO presenter | `npm test -- tests/imagePresenter.test.js` | URL generation, provider internals hidden |
+| Image service | `npm test -- tests/imageService.test.js` | upload/list/delete, cleanup, ownership |
+| Auth provider | `npm test -- tests/firebaseAuthProvider.test.js` | token extraction, normalized user, auth failure |
+| Routes | `npm test -- tests/imageRoutes.test.js` | canonical and compatibility endpoints |
+| Full backend | `npm test` | all backend tests |
+
+---
+
+## 15. Frontend Testing Matrix
+
+| Area | Required command | Required coverage |
+|---|---|---|
+| Image API | `yarn test src/api/images.test.ts` | calls backend endpoints, handles errors |
+| Public gallery | `yarn test` | renders backend image DTOs |
+| User gallery | `yarn test` | authenticated gallery renders backend DTOs |
+| Upload | `yarn test` | calls backend upload wrapper |
+| Delete | `yarn test` | calls backend delete wrapper |
+| Production build | `yarn build` | CRA build succeeds |
+
+---
+
+## 16. Manual Validation Checklist
+
+### Backend
+
+```text
+[ ] /health returns ok.
+[ ] /images/public returns JSON array.
+[ ] /images/me rejects unauthenticated request.
+[ ] /images/me accepts valid Firebase token.
+[ ] POST /images rejects unauthenticated request.
+[ ] POST /images rejects non-image file.
+[ ] POST /images rejects empty payload.
+[ ] POST /images rejects oversize payload.
+[ ] POST /images accepts valid image.
+[ ] POST /resize-upload compatibility endpoint still works.
+[ ] DELETE /images/:imageId deletes owned image.
+[ ] DELETE /images/:imageId rejects non-owner.
+[ ] POST /delete-image compatibility endpoint still works.
+[ ] Uploaded file exists under LOCAL_STORAGE_ROOT.
+[ ] SQLite metadata row is created.
+[ ] Deleted file is removed or no longer reachable.
+[ ] SQLite metadata is deleted or soft-deleted.
+```
+
+### Frontend
+
+```text
+[ ] / renders public gallery from backend API.
+[ ] /login still works with Firebase Auth.
+[ ] /upload remains protected.
+[ ] /upload uploads through backend API.
+[ ] /mygallery remains protected.
+[ ] /mygallery renders current user's backend images.
+[ ] Delete removes image from UI and backend.
+[ ] Loading state still works.
+[ ] Empty state still works.
+[ ] API error state does not crash the app.
+```
+
+### NC110
+
+```text
+[ ] PM2 process starts.
+[ ] pm2 status is healthy.
+[ ] pm2 logs photogram-backend shows no startup config errors.
+[ ] Upload memory usage is acceptable.
+[ ] RESIZE_CONCURRENCY=1 is respected.
+[ ] MAX_FILE_SIZE_MB=5 is respected.
+[ ] ENABLE_DEBUG_ENDPOINT=false in production.
+[ ] SQLite path is writable.
+[ ] Local image directory is writable.
+[ ] Backup path exists or is documented.
+```
+
+---
+
+## 17. Risk Register
+
+### Risk: Frontend still depends on Firestore object shapes
+
+Mitigation:
+
+```text
+Create and use the normalized PhotogramImage DTO before changing many components.
+```
+
+### Risk: Local files are saved outside storage root
+
+Mitigation:
+
+```text
+Path traversal tests are required before wiring local storage into upload routes.
+```
+
+### Risk: Upload stores files but metadata insert fails
+
+Mitigation:
+
+```text
+Image service must clean up saved files if metadata creation fails.
+```
+
+### Risk: Delete removes metadata but not files
+
+Mitigation:
+
+```text
+Delete service should load metadata first, delete files, then mark/delete metadata.
+```
+
+### Risk: SQLite dependency is too heavy or incompatible
+
+Mitigation:
+
+```text
+Choose dependency carefully, test on the Samsung NC110, and keep fallback notes.
+```
+
+### Risk: Sharp is unstable on Atom-class CPU
+
+Mitigation:
+
+```text
+Keep IMAGE_PROCESSOR=sharp|jimp and validate on the target machine.
+```
+
+### Risk: Firebase Auth token handling becomes scattered
+
+Mitigation:
+
+```text
+Keep Firebase token verification inside AuthProvider only. Frontend only supplies token to API wrapper.
+```
+
+---
+
+## 18. Definition of Done for MVP
+
+The MVP is done when all of the following are true:
+
+```text
+[ ] Backend starts with AUTH_PROVIDER=firebase, DATABASE_PROVIDER=sqlite, STORAGE_PROVIDER=local.
+[ ] Provider selection is centralized in config/container code.
+[ ] Controllers and services do not branch on Firebase/sqlite/local provider names.
+[ ] Upload saves image files to LOCAL_STORAGE_ROOT.
+[ ] Upload writes metadata to SQLite.
+[ ] Public gallery reads from backend /images/public.
+[ ] User gallery reads from backend /images/me.
+[ ] Delete removes or soft-deletes both storage and metadata.
+[ ] Frontend gallery/upload/delete code does not directly use Firestore or Firebase Storage.
+[ ] Compatibility endpoints /resize-upload and /delete-image still work or are documented if intentionally replaced.
+[ ] Backend npm test passes.
+[ ] Frontend yarn test passes.
+[ ] Frontend yarn build passes.
+[ ] Manual upload/list/delete test passes locally.
+[ ] NC110 PM2 smoke test passes.
+```
+
+---
+
+## 19. Suggested Next Document After MVP
+
+After this MVP is complete, create:
+
+```text
+docs/local-auth-implementation-plan.md
+```
+
+That document should cover:
+
+```text
+AUTH_PROVIDER=local
+password hashing
+HTTP-only cookies
+session table
+CSRF considerations
+login rate limits
+frontend login/bootstrap migration
+Firebase Auth removal or optional mode
+```
+
+Local auth should not block this MVP.

--- a/docs/photogram-provider-agnostic-system-spec.md
+++ b/docs/photogram-provider-agnostic-system-spec.md
@@ -1,0 +1,1513 @@
+# Photogram Provider-Agnostic System Specification
+
+Status: Draft v1
+Audience: Codex, project maintainers, future contributors
+Primary goal: Make Photogram work the same way regardless of whether data and files come from Firebase or self-hosted services.
+
+---
+
+## 1. Purpose
+
+Photogram started as a Firebase-backed personal photo gallery. Firebase solved authentication, metadata storage, and image storage quickly, but it should no longer be treated as the only foundation of the app.
+
+This specification defines a provider-agnostic architecture where:
+
+- The React frontend talks to a stable Photogram API.
+- The Express backend owns all provider selection and heavy operations.
+- `.env` decides which providers are active.
+- Backend config validates provider choices.
+- Backend composition creates concrete provider instances.
+- Controllers and services receive already-created dependencies.
+- Firebase remains available as an optional provider, not the default assumption.
+
+The intended default deployment is self-hosted on the Samsung NC110 Ubuntu Server using lightweight local services.
+
+---
+
+## 2. Current Project Context
+
+### Frontend
+
+The frontend is a React 17 + TypeScript CRA app in `src/`.
+
+Relevant conventions:
+
+- Components live under `src/components/`.
+- Redux state lives under `src/state/`.
+- API clients live under `src/api/`.
+- Configuration comes from `REACT_APP_*` variables.
+- Tests are colocated as `*.test.tsx` files.
+- The project is Yarn-first.
+
+Current major flows:
+
+- Public gallery: `/`
+- Login: `/login`
+- Protected upload page: `/upload`
+- Protected user gallery: `/mygallery`
+
+Important current files:
+
+- `src/components/App/App.tsx`
+- `src/components/App/AppInitializer.tsx`
+- `src/components/App/ProtectedRoute.tsx`
+- `src/api/images.ts`
+- `src/firebase.configuration.ts`
+
+### Backend
+
+The backend is a separate Express/Firebase service.
+
+Relevant conventions:
+
+- CommonJS JavaScript.
+- 4-space indentation.
+- Semicolons.
+- Single quotes.
+- Lowercase hyphenated endpoint paths.
+- `index.js` should stay a thin startup entrypoint.
+- `app.js` should compose middleware, routes, and error handlers.
+- `config/` owns environment parsing and provider initialization.
+- `controllers/` own request handlers.
+- `routes/` own route wiring.
+- `middleware/` owns upload, CORS, size guards, rate limits, and error handling.
+- `utils/` owns shared helpers such as logging and semaphores.
+- Tests live under `tests/` and use `node:test` plus `node:assert/strict`.
+
+Deployment target:
+
+- Samsung Netbook NC110
+- Ubuntu Server 24.04.3 LTS
+- Intel Atom CPU
+- 2GB RAM
+- 250GB SSD
+- PM2-managed process
+
+Operational constraints:
+
+- Prefer low-memory and low-CPU changes.
+- Stream I/O where practical.
+- Avoid loading large buffers unnecessarily.
+- Keep dependencies lightweight.
+- Validate `sharp` versus `jimp` on target hardware.
+- Keep upload concurrency low.
+
+---
+
+## 3. Goals
+
+1. Make Firebase optional.
+2. Make local self-hosted services the default direction.
+3. Keep the frontend source-agnostic.
+4. Move gallery metadata access behind backend APIs.
+5. Move image storage, deletion, URL resolution, resizing, compression, and safety controls behind backend providers.
+6. Allow provider switching through `.env` without changing controllers, services, or frontend feature code.
+7. Preserve the current user-facing functionality.
+8. Preserve compatibility with existing endpoints during migration where practical.
+9. Keep the system small enough to run reliably on the NC110.
+
+---
+
+## 4. Non-Goals
+
+1. Do not build a generic Firebase clone.
+2. Do not introduce Docker, MinIO, PostgreSQL, Redis, or background workers as first-step requirements.
+3. Do not rewrite the entire frontend at once.
+4. Do not remove Firebase Auth immediately unless local auth is explicitly implemented in that phase.
+5. Do not expose local filesystem layout or provider internals to the frontend.
+6. Do not make `.env` able to load arbitrary JavaScript modules.
+7. Do not store provider-specific URLs as the permanent source of truth.
+
+---
+
+## 5. Core Architecture Rule
+
+The architectural rule is:
+
+```text
+.env chooses providers.
+config validates providers.
+container creates providers.
+services use provider interfaces.
+controllers call services.
+routes wire controllers.
+frontend calls the Photogram API.
+```
+
+The frontend must not care whether Photogram uses:
+
+- Firebase Auth
+- local auth
+- Firestore
+- SQLite
+- Firebase Storage
+- local filesystem storage
+- a future provider
+
+Controllers and services must not branch on provider names.
+
+Forbidden outside `config/` or composition code:
+
+```js
+if (process.env.DATABASE_PROVIDER === 'firebase') {
+    // ...
+}
+```
+
+Forbidden everywhere:
+
+```js
+require(process.env.IMAGE_REPOSITORY_MODULE);
+```
+
+Allowed pattern:
+
+```js
+const imageRepository = resolveProvider(
+    imageRepositories,
+    config.databaseProvider,
+    'database'
+).createImageRepository(config);
+```
+
+The selected implementation should be resolved once at startup and then injected.
+
+---
+
+## 6. Target Runtime Architecture
+
+```text
+React frontend
+  |
+  | Stable Photogram HTTP API
+  v
+Express backend
+  |
+  |-- AuthProvider
+  |-- ImageRepository
+  |-- StorageProvider
+  |-- ImageProcessor
+  |
+  v
+Provider implementations
+  |
+  |-- Firebase Auth, Firestore, Firebase Storage
+  |-- local auth, SQLite, local filesystem
+  |-- future providers
+```
+
+The backend owns:
+
+- authentication verification
+- authorization decisions
+- image upload validation
+- image resize/compression
+- thumbnail generation
+- storage writes/deletes
+- metadata writes/deletes
+- provider-specific URL generation
+- rate limits
+- file-size limits
+- low-memory safeguards
+
+The frontend owns:
+
+- UI composition
+- route rendering
+- form state
+- gallery rendering
+- upload user experience
+- Redux state
+- calls to `src/api/*`
+
+---
+
+## 7. Provider Types
+
+Photogram has three major provider categories.
+
+### 7.1 AuthProvider
+
+Responsible for identifying the current user and enforcing authenticated routes.
+
+Initial provider options:
+
+- `firebase`
+- `local` later
+
+### 7.2 ImageRepository
+
+Responsible for image metadata.
+
+Initial provider options:
+
+- `firebase`
+- `sqlite`
+
+### 7.3 StorageProvider
+
+Responsible for image files and URL resolution.
+
+Initial provider options:
+
+- `firebase`
+- `local`
+
+---
+
+## 8. Default Provider Direction
+
+The desired long-term default is:
+
+```env
+AUTH_PROVIDER=local
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+```
+
+The practical migration default may initially be:
+
+```env
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+```
+
+Firebase-compatible mode remains:
+
+```env
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=firebase
+STORAGE_PROVIDER=firebase
+```
+
+---
+
+## 9. Provider Configuration
+
+### 9.1 Local/SQLite Default
+
+```env
+NODE_ENV=production
+PORT=3000
+
+AUTH_PROVIDER=local
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+
+SQLITE_PATH=/var/lib/photogram/photogram.sqlite
+LOCAL_STORAGE_ROOT=/var/lib/photogram/images
+PUBLIC_MEDIA_BASE_URL=https://photos.example.com/media
+
+LOW_MEMORY_MODE=true
+MAX_FILE_SIZE_MB=5
+RESIZE_CONCURRENCY=1
+HEAVY_RATE_LIMIT_MAX=8
+ENABLE_DEBUG_ENDPOINT=false
+IMAGE_PROCESSOR=sharp
+```
+
+### 9.2 Transitional Mode: Firebase Auth + Local Data/Storage
+
+```env
+NODE_ENV=production
+PORT=3000
+
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+
+SQLITE_PATH=/var/lib/photogram/photogram.sqlite
+LOCAL_STORAGE_ROOT=/var/lib/photogram/images
+PUBLIC_MEDIA_BASE_URL=https://photos.example.com/media
+
+FIREBASE_SERVICE_ACCOUNT_PATH=/secure/photogram/firebase-service-account.json
+
+LOW_MEMORY_MODE=true
+MAX_FILE_SIZE_MB=5
+RESIZE_CONCURRENCY=1
+HEAVY_RATE_LIMIT_MAX=8
+ENABLE_DEBUG_ENDPOINT=false
+IMAGE_PROCESSOR=sharp
+```
+
+### 9.3 Firebase Mode
+
+```env
+NODE_ENV=production
+PORT=3000
+
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=firebase
+STORAGE_PROVIDER=firebase
+
+FIREBASE_SERVICE_ACCOUNT_PATH=/secure/photogram/firebase-service-account.json
+FIREBASE_STORAGE_BUCKET=your-bucket.appspot.com
+FIREBASE_URL_MODE=signed
+FIREBASE_SIGNED_URL_EXPIRES_SECONDS=300
+
+LOW_MEMORY_MODE=true
+MAX_FILE_SIZE_MB=5
+RESIZE_CONCURRENCY=1
+HEAVY_RATE_LIMIT_MAX=8
+ENABLE_DEBUG_ENDPOINT=false
+IMAGE_PROCESSOR=sharp
+```
+
+---
+
+## 10. Configuration Validation Rules
+
+`config/env.js` should parse and normalize all env values.
+
+`config/container.js` or equivalent composition code should validate provider combinations.
+
+Required validation:
+
+1. `AUTH_PROVIDER` must be one of the supported auth provider keys.
+2. `DATABASE_PROVIDER` must be one of the supported repository provider keys.
+3. `STORAGE_PROVIDER` must be one of the supported storage provider keys.
+4. `DATABASE_PROVIDER=sqlite` requires `SQLITE_PATH`.
+5. `STORAGE_PROVIDER=local` requires `LOCAL_STORAGE_ROOT`.
+6. `STORAGE_PROVIDER=local` requires either `PUBLIC_MEDIA_BASE_URL` for public media URLs or a backend media route.
+7. Any Firebase provider requires `FIREBASE_SERVICE_ACCOUNT_PATH`.
+8. `STORAGE_PROVIDER=firebase` requires `FIREBASE_STORAGE_BUCKET`.
+9. `FIREBASE_URL_MODE` must be `public` or `signed`.
+10. Numeric env values must be parsed once and validated as safe integers.
+11. Provider names must not be used as raw module paths.
+
+Invalid config should fail fast during startup.
+
+---
+
+## 11. Backend Composition Pattern
+
+### 11.1 Startup
+
+`index.js` remains thin:
+
+```js
+require('dotenv').config();
+
+const { readEnv } = require('./config/env');
+const { createContainer } = require('./config/container');
+const createApp = require('./app');
+
+const config = readEnv();
+const container = createContainer(config);
+const app = createApp(container);
+
+app.listen(config.port, () => {
+    console.log(`Photogram backend listening on port ${config.port}`);
+});
+```
+
+### 11.2 App Composition
+
+`app.js` receives dependencies:
+
+```js
+const express = require('express');
+const createImageRoutes = require('./routes/imageRoutes');
+const createAuthRoutes = require('./routes/authRoutes');
+const createSystemRoutes = require('./routes/systemRoutes');
+
+function createApp(container) {
+    const app = express();
+
+    app.use('/health', createSystemRoutes(container));
+    app.use('/auth', createAuthRoutes(container));
+    app.use('/images', createImageRoutes(container));
+
+    return app;
+}
+
+module.exports = createApp;
+```
+
+### 11.3 Container
+
+Provider resolution belongs in one composition layer:
+
+```js
+const sqliteImageRepository = require('../repositories/sqliteImageRepository');
+const firebaseImageRepository = require('../repositories/firebaseImageRepository');
+const localStorageProvider = require('../storage/localStorageProvider');
+const firebaseStorageProvider = require('../storage/firebaseStorageProvider');
+const localAuthProvider = require('../auth/localAuthProvider');
+const firebaseAuthProvider = require('../auth/firebaseAuthProvider');
+const imageService = require('../services/imageService');
+
+const imageRepositories = {
+    sqlite: sqliteImageRepository,
+    firebase: firebaseImageRepository
+};
+
+const storageProviders = {
+    local: localStorageProvider,
+    firebase: firebaseStorageProvider
+};
+
+const authProviders = {
+    local: localAuthProvider,
+    firebase: firebaseAuthProvider
+};
+
+function resolveProvider(registry, providerName, providerType) {
+    const provider = registry[providerName];
+
+    if (!provider) {
+        throw new Error(`Unsupported ${providerType} provider: ${providerName}`);
+    }
+
+    return provider;
+}
+
+function createContainer(config) {
+    const imageRepository = resolveProvider(
+        imageRepositories,
+        config.databaseProvider,
+        'database'
+    ).createImageRepository(config);
+
+    const storageProvider = resolveProvider(
+        storageProviders,
+        config.storageProvider,
+        'storage'
+    ).createStorageProvider(config);
+
+    const authProvider = resolveProvider(
+        authProviders,
+        config.authProvider,
+        'auth'
+    ).createAuthProvider(config);
+
+    const images = imageService.createImageService({
+        imageRepository,
+        storageProvider,
+        authProvider,
+        config
+    });
+
+    return {
+        config,
+        authProvider,
+        imageRepository,
+        storageProvider,
+        imageService: images
+    };
+}
+
+module.exports = {
+    createContainer
+};
+```
+
+The exact file names can change, but the rule should not: provider choice is resolved once and injected.
+
+---
+
+## 12. Provider Contracts
+
+Provider contracts should be small and explicit.
+
+### 12.1 ImageRepository Contract
+
+```js
+function createImageRepository(config) {
+    async function listPublicImages(options) {}
+    async function listImagesByOwner(ownerId, options) {}
+    async function findImageById(imageId) {}
+    async function createImage(imageRecord) {}
+    async function updateImage(imageId, updates) {}
+    async function deleteImageById(imageId, ownerId) {}
+
+    return {
+        listPublicImages,
+        listImagesByOwner,
+        findImageById,
+        createImage,
+        updateImage,
+        deleteImageById
+    };
+}
+```
+
+Repository methods return internal image records, not frontend DTOs.
+
+### 12.2 StorageProvider Contract
+
+```js
+function createStorageProvider(config) {
+    async function saveObject(input) {}
+    async function deleteObject(storageKey) {}
+    async function getUrl(storageKey, options) {}
+    async function exists(storageKey) {}
+
+    return {
+        saveObject,
+        deleteObject,
+        getUrl,
+        exists
+    };
+}
+```
+
+`saveObject(input)` should accept a normalized object such as:
+
+```js
+{
+    storageKey: 'users/user_123/images/img_abc.webp',
+    buffer,
+    readableStream,
+    contentType: 'image/webp',
+    sizeBytes: 12345
+}
+```
+
+The implementation may accept either `buffer` or `readableStream`, but it should prefer streaming where practical.
+
+### 12.3 AuthProvider Contract
+
+```js
+function createAuthProvider(config) {
+    async function getCurrentUser(req) {}
+    async function requireUser(req) {}
+    async function login(credentials, res) {}
+    async function logout(req, res) {}
+
+    return {
+        getCurrentUser,
+        requireUser,
+        login,
+        logout
+    };
+}
+```
+
+For Firebase Auth, `login` may be unsupported by the backend during the transition because the frontend still signs in with Firebase. In that case, the provider should implement `getCurrentUser` and `requireUser` by validating an ID token sent by the frontend.
+
+For local auth, `login` and `logout` should use secure HTTP-only cookies.
+
+---
+
+## 13. Internal Image Record
+
+The backend database should store provider-neutral metadata.
+
+Internal record shape:
+
+```js
+{
+    id: 'img_abc',
+    ownerId: 'user_123',
+    title: 'Optional title',
+    description: 'Optional description',
+    storageKey: 'users/user_123/images/img_abc.webp',
+    thumbnailKey: 'users/user_123/thumbnails/img_abc.webp',
+    originalStorageKey: 'users/user_123/originals/img_abc.jpg',
+    mimeType: 'image/webp',
+    originalMimeType: 'image/jpeg',
+    width: 1600,
+    height: 1200,
+    thumbnailWidth: 400,
+    thumbnailHeight: 300,
+    sizeBytes: 234567,
+    originalSizeBytes: 3456789,
+    isPublic: true,
+    createdAt: '2026-06-22T12:00:00.000Z',
+    updatedAt: '2026-06-22T12:00:00.000Z',
+    deletedAt: null
+}
+```
+
+Important rule:
+
+```text
+Database stores storage keys.
+Backend generates URLs.
+Frontend receives URLs.
+```
+
+Do not treat Firebase Storage URLs, signed URLs, or local `/media/*` URLs as the permanent database source of truth.
+
+---
+
+## 14. Frontend Image DTO
+
+The frontend should receive a normalized provider-neutral DTO.
+
+```ts
+export type PhotogramImage = {
+    id: string;
+    ownerId?: string;
+    title?: string;
+    description?: string;
+    imageUrl: string;
+    thumbnailUrl?: string;
+    width?: number;
+    height?: number;
+    sizeBytes?: number;
+    mimeType?: string;
+    isPublic: boolean;
+    createdAt: string;
+    updatedAt?: string;
+};
+```
+
+Do not expose `storageKey` or `thumbnailKey` to the frontend unless there is a specific administrative/debug reason.
+
+The DTO should be created by a backend presenter/mapper, for example:
+
+```js
+async function toImageDto(imageRecord, storageProvider) {
+    return {
+        id: imageRecord.id,
+        ownerId: imageRecord.ownerId,
+        title: imageRecord.title,
+        description: imageRecord.description,
+        imageUrl: await storageProvider.getUrl(imageRecord.storageKey, {
+            visibility: imageRecord.isPublic ? 'public' : 'private'
+        }),
+        thumbnailUrl: imageRecord.thumbnailKey
+            ? await storageProvider.getUrl(imageRecord.thumbnailKey, {
+                visibility: imageRecord.isPublic ? 'public' : 'private'
+            })
+            : undefined,
+        width: imageRecord.width,
+        height: imageRecord.height,
+        sizeBytes: imageRecord.sizeBytes,
+        mimeType: imageRecord.mimeType,
+        isPublic: imageRecord.isPublic,
+        createdAt: imageRecord.createdAt,
+        updatedAt: imageRecord.updatedAt
+    };
+}
+```
+
+---
+
+## 15. Canonical Backend API
+
+Canonical endpoints should be provider-neutral.
+
+```text
+GET    /health
+
+GET    /auth/me
+POST   /auth/login
+POST   /auth/logout
+
+GET    /images/public
+GET    /images/me
+POST   /images
+DELETE /images/:imageId
+GET    /images/:imageId/file
+GET    /images/:imageId/thumbnail
+```
+
+### 15.1 Compatibility Endpoints
+
+Preserve current endpoints during migration where practical:
+
+```text
+POST   /resize-upload
+POST   /delete-image
+```
+
+These can internally call the same service methods as the canonical routes.
+
+Existing test/manual validation targets should remain valid during migration:
+
+```text
+GET/POST as applicable:
+/health
+/resize
+/upload
+/resize-upload
+/delete-image
+```
+
+---
+
+## 16. API Response Shapes
+
+### 16.1 List Public Images
+
+Request:
+
+```text
+GET /images/public
+```
+
+Response:
+
+```json
+{
+    "images": [
+        {
+            "id": "img_abc",
+            "ownerId": "user_123",
+            "title": "Photo title",
+            "description": "Photo description",
+            "imageUrl": "https://photos.example.com/media/users/user_123/images/img_abc.webp",
+            "thumbnailUrl": "https://photos.example.com/media/users/user_123/thumbnails/img_abc.webp",
+            "width": 1600,
+            "height": 1200,
+            "sizeBytes": 234567,
+            "mimeType": "image/webp",
+            "isPublic": true,
+            "createdAt": "2026-06-22T12:00:00.000Z",
+            "updatedAt": "2026-06-22T12:00:00.000Z"
+        }
+    ]
+}
+```
+
+### 16.2 List Current User Images
+
+Request:
+
+```text
+GET /images/me
+```
+
+Response:
+
+```json
+{
+    "images": []
+}
+```
+
+### 16.3 Upload Image
+
+Request:
+
+```text
+POST /images
+Content-Type: multipart/form-data
+```
+
+Fields:
+
+```text
+image: file
+isPublic: true|false
+ title: optional string
+ description: optional string
+```
+
+Response:
+
+```json
+{
+    "image": {
+        "id": "img_abc",
+        "ownerId": "user_123",
+        "title": "Photo title",
+        "description": "Photo description",
+        "imageUrl": "https://photos.example.com/media/users/user_123/images/img_abc.webp",
+        "thumbnailUrl": "https://photos.example.com/media/users/user_123/thumbnails/img_abc.webp",
+        "width": 1600,
+        "height": 1200,
+        "sizeBytes": 234567,
+        "mimeType": "image/webp",
+        "isPublic": true,
+        "createdAt": "2026-06-22T12:00:00.000Z",
+        "updatedAt": "2026-06-22T12:00:00.000Z"
+    }
+}
+```
+
+### 16.4 Delete Image
+
+Request:
+
+```text
+DELETE /images/img_abc
+```
+
+Response:
+
+```json
+{
+    "ok": true
+}
+```
+
+---
+
+## 17. Upload Flow
+
+The upload flow is owned by the backend.
+
+```text
+1. Route receives multipart upload.
+2. Middleware applies size limits and rate limits.
+3. AuthProvider identifies the current user.
+4. Controller calls imageService.uploadImage().
+5. Service validates file presence, MIME type, and size.
+6. Service calls image processor to resize/compress.
+7. Service creates storage keys.
+8. StorageProvider saves processed image.
+9. StorageProvider saves thumbnail.
+10. ImageRepository saves metadata.
+11. Service maps internal record to frontend DTO.
+12. Controller returns JSON.
+```
+
+Required safeguards:
+
+- Reject empty payloads.
+- Reject non-image files.
+- Reject oversized payloads based on `MAX_FILE_SIZE_MB`.
+- Apply upload/heavy endpoint rate limiting.
+- Limit resize concurrency using `RESIZE_CONCURRENCY`.
+- Avoid path traversal in generated storage keys.
+- Clean up partially written files if repository save fails.
+- Clean up repository record if storage save fails after partial metadata creation.
+
+---
+
+## 18. Delete Flow
+
+The delete flow is owned by the backend.
+
+```text
+1. AuthProvider identifies the current user.
+2. Controller calls imageService.deleteImage(imageId, user).
+3. Service loads image metadata.
+4. Service confirms ownership or authorization.
+5. Service deletes image and thumbnail from StorageProvider.
+6. Service deletes or soft-deletes metadata from ImageRepository.
+7. Controller returns `{ ok: true }`.
+```
+
+Default behavior should be hard delete for personal deployments unless soft delete is intentionally added.
+
+If soft delete is used, set `deletedAt` and exclude deleted rows/documents from normal list queries.
+
+Delete must be idempotent where practical. Deleting an already-missing storage object should not leave the system broken.
+
+---
+
+## 19. Local Storage Provider
+
+The local storage provider should write files under:
+
+```text
+/var/lib/photogram/images
+```
+
+Suggested layout:
+
+```text
+/var/lib/photogram/images/
+  users/
+    <ownerId>/
+      originals/
+      images/
+      thumbnails/
+  public/
+```
+
+Recommended storage keys:
+
+```text
+users/<ownerId>/images/<imageId>.webp
+users/<ownerId>/thumbnails/<imageId>.webp
+users/<ownerId>/originals/<imageId>.<ext>
+```
+
+Rules:
+
+1. Storage keys are logical keys, not arbitrary user-supplied paths.
+2. Never concatenate unchecked user input into filesystem paths.
+3. Resolve paths and verify they remain inside `LOCAL_STORAGE_ROOT`.
+4. Use atomic writes where practical.
+5. Delete derived files on failed upload.
+6. Use restrictive filesystem permissions.
+7. Do not serve private files directly from a public static route.
+
+### 19.1 Public File Serving
+
+For public images, either:
+
+1. Serve `/media/*` through Nginx/Caddy from `LOCAL_STORAGE_ROOT`; or
+2. Serve files through Express if traffic is very low.
+
+For the NC110, static serving through Nginx/Caddy is preferred for public images.
+
+### 19.2 Private File Serving
+
+Private user gallery files should not be exposed as direct public files.
+
+Acceptable options:
+
+1. Backend checks auth and streams the file.
+2. Backend checks auth and delegates with `X-Accel-Redirect` to Nginx.
+3. Backend returns short-lived signed local URLs if implemented later.
+
+Start simple: backend-authenticated streaming is acceptable for a personal deployment.
+
+---
+
+## 20. SQLite Image Repository
+
+SQLite is the preferred first local database because it is lightweight and simple to back up.
+
+Suggested table:
+
+```sql
+CREATE TABLE IF NOT EXISTS images (
+    id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    title TEXT,
+    description TEXT,
+    storage_key TEXT NOT NULL,
+    thumbnail_key TEXT,
+    original_storage_key TEXT,
+    mime_type TEXT,
+    original_mime_type TEXT,
+    width INTEGER,
+    height INTEGER,
+    thumbnail_width INTEGER,
+    thumbnail_height INTEGER,
+    size_bytes INTEGER,
+    original_size_bytes INTEGER,
+    is_public INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_images_public_created_at
+ON images (is_public, created_at DESC)
+WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_images_owner_created_at
+ON images (owner_id, created_at DESC)
+WHERE deleted_at IS NULL;
+```
+
+Potential future local-auth tables:
+
+```sql
+CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    display_name TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    token_hash TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+SQLite implementation rules:
+
+- Initialize schema at startup or through an explicit migration command.
+- Use parameterized queries.
+- Keep queries simple.
+- Do not add an ORM unless there is a clear benefit.
+- Enable WAL mode if it works reliably on the deployment filesystem.
+- Back up the SQLite file together with the image folder.
+
+---
+
+## 21. Firebase Providers
+
+Firebase provider implementations should remain available but isolated.
+
+### 21.1 Firebase Auth Provider
+
+Responsibilities:
+
+- Validate Firebase ID tokens.
+- Return a normalized user object.
+
+Normalized user shape:
+
+```js
+{
+    id: 'firebase-uid',
+    email: 'person@example.com',
+    displayName: 'Optional Name',
+    provider: 'firebase'
+}
+```
+
+### 21.2 Firebase Image Repository
+
+Responsibilities:
+
+- Read/write image metadata from Firestore.
+- Map Firestore documents to internal image records.
+- Map internal image records back to Firestore-safe data.
+
+Firestore document shape should align with the internal image record as much as possible.
+
+### 21.3 Firebase Storage Provider
+
+Responsibilities:
+
+- Save objects to Firebase Storage.
+- Delete Firebase Storage objects.
+- Generate public or signed URLs depending on config.
+
+Provider-specific URLs should still be generated at response time, not treated as permanent database truth.
+
+---
+
+## 22. Frontend API Boundary
+
+Frontend feature code should call local API wrappers only.
+
+Recommended files:
+
+```text
+src/api/images.ts
+src/api/auth.ts
+src/config.ts
+```
+
+`src/api/images.ts` should expose provider-neutral functions:
+
+```ts
+export async function getPublicImages(): Promise<PhotogramImage[]> {}
+export async function getMyImages(): Promise<PhotogramImage[]> {}
+export async function uploadImage(input: UploadImageInput): Promise<PhotogramImage> {}
+export async function deleteImage(imageId: string): Promise<void> {}
+```
+
+Components and Redux thunks should not directly import Firestore or Firebase Storage.
+
+Allowed during transition:
+
+- Firebase Auth usage in app initialization/login while `AUTH_PROVIDER=firebase` remains active.
+
+Not allowed after migration of gallery/upload/delete:
+
+- Gallery components reading directly from Firestore.
+- Upload components writing directly to Firebase Storage.
+- Delete flows deleting directly from Firebase Storage.
+- Frontend storing provider-specific object paths as business logic.
+
+Frontend environment:
+
+```env
+REACT_APP_API_URL=https://photos.example.com
+REACT_APP_AUTH_PROVIDER=firebase
+```
+
+Later local-auth mode:
+
+```env
+REACT_APP_API_URL=https://photos.example.com
+REACT_APP_AUTH_PROVIDER=local
+```
+
+The frontend can know the auth mode only for login/bootstrap behavior. It should not know database or storage provider modes.
+
+---
+
+## 23. Auth Migration Strategy
+
+### Phase A: Keep Firebase Auth
+
+Frontend signs users in with Firebase.
+
+For authenticated backend requests, frontend sends Firebase ID token:
+
+```text
+Authorization: Bearer <firebase-id-token>
+```
+
+Backend validates the token through `AuthProvider=firebase`.
+
+This allows local database/storage migration without immediately rewriting login.
+
+### Phase B: Add Local Auth
+
+Backend implements:
+
+```text
+POST /auth/login
+POST /auth/logout
+GET  /auth/me
+```
+
+Local auth should use:
+
+- password hashing with a safe library
+- HTTP-only cookies
+- `SameSite` cookie settings
+- secure cookies in production behind HTTPS
+- login rate limiting
+- session expiration
+
+Frontend switches login/bootstrap behavior through `REACT_APP_AUTH_PROVIDER=local`.
+
+---
+
+## 24. Migration Phases
+
+### Phase 1: Backend Composition Layer
+
+Add:
+
+```text
+config/env.js
+config/container.js
+repositories/
+storage/
+auth/
+services/
+```
+
+Goal:
+
+- Existing backend behavior still works.
+- Provider selection is centralized.
+- Controllers/services do not branch on provider names.
+
+### Phase 2: Local Storage Provider
+
+Add `STORAGE_PROVIDER=local`.
+
+Goal:
+
+- `/resize-upload` can save processed images to local filesystem.
+- `/delete-image` can delete local files.
+- Firebase Storage is no longer required for upload/delete in local mode.
+
+### Phase 3: SQLite Image Repository
+
+Add `DATABASE_PROVIDER=sqlite`.
+
+Goal:
+
+- Upload creates SQLite metadata.
+- Delete removes or soft-deletes SQLite metadata.
+- `GET /images/public` and `GET /images/me` return SQLite-backed data.
+
+### Phase 4: Frontend Gallery API Migration
+
+Update frontend gallery flows to use backend API.
+
+Goal:
+
+- Public gallery uses `GET /images/public`.
+- User gallery uses `GET /images/me`.
+- Gallery state no longer depends on Firestore directly.
+
+### Phase 5: Frontend Upload/Delete API Migration
+
+Update frontend upload/delete flows to use canonical backend API.
+
+Goal:
+
+- Upload uses `POST /images` or compatibility `POST /resize-upload`.
+- Delete uses `DELETE /images/:imageId` or compatibility `POST /delete-image`.
+- Components remain provider-agnostic.
+
+### Phase 6: Local Auth
+
+Add `AUTH_PROVIDER=local`.
+
+Goal:
+
+- Firebase is fully optional.
+- Default deployment can be local auth + SQLite + local filesystem.
+
+---
+
+## 25. Testing Requirements
+
+### 25.1 Backend Unit Tests
+
+Use `node:test` and `node:assert/strict`.
+
+Required tests:
+
+- env parsing and defaults
+- invalid provider names fail startup validation
+- missing required env for selected provider fails startup validation
+- provider registry resolves allowed providers only
+- container injects expected service dependencies
+- image DTO mapping calls `storageProvider.getUrl()`
+- SQLite repository creates/list/find/delete image metadata
+- local storage provider rejects path traversal
+- local storage provider saves and deletes objects
+- upload service handles storage failure cleanup
+- delete service handles missing file idempotently where practical
+
+### 25.2 Backend Manual Validation
+
+Validate with `curl` or Postman:
+
+```text
+/health
+/resize
+/upload
+/resize-upload
+/delete-image
+/images/public
+/images/me
+/images/:imageId
+```
+
+For upload endpoints, test:
+
+- valid image
+- non-image file
+- empty payload
+- oversize payload based on `MAX_FILE_SIZE_MB`
+- authenticated request
+- unauthenticated request
+
+### 25.3 Frontend Tests
+
+Use Jest + React Testing Library.
+
+Required tests:
+
+- public gallery renders images from backend API response
+- user gallery renders images from backend API response
+- upload flow calls backend API wrapper
+- delete flow calls backend API wrapper
+- protected route behavior remains correct
+- Firebase-specific gallery/upload behavior is removed or isolated
+
+---
+
+## 26. Security Requirements
+
+1. Do not commit secrets.
+2. Keep Firebase service account JSON outside the repository.
+3. Validate upload MIME type and file extension.
+4. Reject non-image uploads.
+5. Reject oversized uploads.
+6. Prevent path traversal in local storage.
+7. Do not expose private files through public static routes.
+8. Use authorization checks before serving private images.
+9. Use short TTLs for signed URLs when using signed URL mode.
+10. Keep CORS allowlists explicit.
+11. Use rate limits on heavy endpoints.
+12. Avoid debug endpoints in production unless explicitly enabled.
+13. Do not expose raw stack traces to clients in production.
+
+---
+
+## 27. NC110 Operational Requirements
+
+The default local deployment must be realistic for the Samsung NC110.
+
+Requirements:
+
+- Keep image processing concurrency low.
+- Keep memory usage low.
+- Avoid unnecessary daemons.
+- Prefer SQLite over a separate database server initially.
+- Prefer local filesystem over object storage initially.
+- Prefer Nginx/Caddy static serving for public media when configured.
+- Keep PM2 process configuration documented.
+- Validate `sharp` on target hardware; support `jimp` fallback if needed.
+- Test PM2 after deployment:
+
+```text
+pm2 status
+pm2 logs photogram-backend
+```
+
+Suggested local paths:
+
+```text
+/var/lib/photogram/photogram.sqlite
+/var/lib/photogram/images
+/var/backups/photogram
+```
+
+Backup strategy:
+
+```text
+1. Stop or briefly pause writes if necessary.
+2. Copy SQLite database.
+3. Copy image folder.
+4. Store backup outside the application directory.
+5. Periodically test restore.
+```
+
+---
+
+## 28. Files Likely to Change
+
+### Backend
+
+Likely additions:
+
+```text
+config/env.js
+config/container.js
+auth/firebaseAuthProvider.js
+auth/localAuthProvider.js
+repositories/firebaseImageRepository.js
+repositories/sqliteImageRepository.js
+storage/firebaseStorageProvider.js
+storage/localStorageProvider.js
+services/imageService.js
+services/imagePresenter.js
+services/imageProcessor.js
+routes/authRoutes.js
+routes/imageRoutes.js
+controllers/authController.js
+controllers/imageController.js
+tests/config.test.js
+tests/container.test.js
+tests/sqliteImageRepository.test.js
+tests/localStorageProvider.test.js
+tests/imageService.test.js
+```
+
+Likely updates:
+
+```text
+index.js
+app.js
+config/firebase.js
+middleware/upload.js
+middleware/rateLimit.js
+controllers/*
+routes/*
+package.json
+```
+
+### Frontend
+
+Likely additions/updates:
+
+```text
+src/api/images.ts
+src/api/auth.ts
+src/config.ts
+src/state/*
+src/components/Gallery/*
+src/components/Login/*
+src/components/App/AppInitializer.tsx
+src/components/App/ProtectedRoute.tsx
+```
+
+Firebase-specific frontend code should remain only where needed for Firebase Auth during the transition.
+
+---
+
+## 29. Definition of Done
+
+The provider-agnostic migration is done when:
+
+1. Frontend gallery/upload/delete flows call only the Photogram API.
+2. Frontend gallery/upload/delete flows do not directly use Firestore or Firebase Storage.
+3. Backend provider selection happens only in config/composition.
+4. Controllers and services do not branch on provider names.
+5. `DATABASE_PROVIDER=sqlite` works for gallery metadata.
+6. `STORAGE_PROVIDER=local` works for image upload/delete/URL generation.
+7. Firebase mode still works or is intentionally documented as pending.
+8. Tests cover config validation, provider resolution, upload, delete, and gallery list behavior.
+9. Manual validation confirms key endpoints.
+10. Deployment notes confirm NC110-safe runtime settings.
+
+---
+
+## 30. Codex Implementation Guidance
+
+When using Codex, prefer small, focused tasks.
+
+Suggested task order:
+
+1. Add `config/env.js` provider parsing and validation tests.
+2. Add `config/container.js` with provider registries and tests.
+3. Extract current Firebase storage logic into `storage/firebaseStorageProvider.js`.
+4. Add `storage/localStorageProvider.js` and tests.
+5. Extract current Firestore logic into `repositories/firebaseImageRepository.js`.
+6. Add `repositories/sqliteImageRepository.js` and tests.
+7. Add `services/imageService.js` and `services/imagePresenter.js`.
+8. Wire existing upload/delete routes through `imageService`.
+9. Add canonical `/images` routes while preserving compatibility endpoints.
+10. Update frontend `src/api/images.ts` to call backend APIs.
+11. Update gallery state to consume backend image DTOs.
+12. Update upload/delete UI to use backend API wrappers.
+13. Add local auth only after local database and storage are stable.
+
+Each Codex change should include:
+
+- files changed
+- env/config changes
+- tests added or updated
+- manual validation command when endpoint behavior changes
+
+---
+
+## 31. Open Questions
+
+These do not block Phase 1, but should be decided before final local-only mode.
+
+1. Should local delete be hard delete or soft delete by default?
+2. Should original uploads be retained, or only processed images and thumbnails?
+3. Should private images be streamed by Express or served through Nginx `X-Accel-Redirect`?
+4. Should local auth use username/password only, or support passwordless links later?
+5. Should public media URLs include cache-busting versions?
+6. Should image visibility be editable after upload?
+7. Should SQLite migrations be automatic on startup or explicit commands?
+8. Should EXIF metadata be stripped by default?
+9. Should generated files use `.webp` by default, with fallback to `.jpg`?
+10. Should the backend expose paginated image listing in the first migration?
+
+Recommended initial answers:
+
+1. Hard delete for personal deployment.
+2. Do not retain originals unless explicitly enabled.
+3. Stream private files through Express first; optimize later.
+4. Username/password local auth later.
+5. Add `updatedAt` or version query only if caching issues appear.
+6. Not required for first migration.
+7. Automatic lightweight schema initialization is acceptable early.
+8. Strip EXIF by default for privacy.
+9. Prefer `.webp` when supported by processor; fallback to `.jpg` if needed.
+10. Add simple limit/offset or cursor before galleries grow large.
+
+---
+
+## 32. Summary
+
+Photogram should become provider-agnostic by moving all source-specific behavior into backend providers selected at startup.
+
+The frontend should call stable API functions and render normalized DTOs.
+
+The backend should own provider selection, image processing, metadata, storage, URL resolution, authorization, and safety controls.
+
+Firebase remains an available provider, but the intended default path is local services:
+
+```env
+AUTH_PROVIDER=local
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+```
+
+The safest migration path is:
+
+```text
+Firebase Auth first,
+SQLite metadata next,
+local filesystem storage next,
+frontend API migration next,
+local auth last.
+```

--- a/index.js
+++ b/index.js
@@ -1,11 +1,16 @@
 require('dotenv').config();
 
-const { PORT } = require('./config/env');
 const { createApp } = require('./app');
+const { config } = require('./config/env');
+const { getBucket } = require('./config/firebase');
+const { createContainer } = require('./config/container');
+const { createProviderRegistry } = require('./config/providerRegistry');
 const { log } = require('./utils/logger');
 
-const app = createApp();
+const providerRegistry = createProviderRegistry();
+const container = createContainer(config, providerRegistry);
+const app = createApp({ container, legacyBucketGetter: getBucket });
 
-app.listen(PORT, '0.0.0.0', () => {
-    log('info', 'Server is running', { port: PORT });
+app.listen(config.port, '0.0.0.0', () => {
+    log('info', 'Server is running', { port: config.port });
 });

--- a/middleware/cors.js
+++ b/middleware/cors.js
@@ -10,6 +10,9 @@ const allowedOrigins = new Set([
     'https://photogram.andreszenteno.com',
 ]);
 
+const allowedMethods = ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'];
+const allowedHeaders = ['Content-Type', 'Authorization'];
+
 const corsMiddleware = cors({
     origin: (origin, callback) => {
         if (!origin || allowedOrigins.has(origin)) {
@@ -18,9 +21,14 @@ const corsMiddleware = cors({
             callback(new Error('Not allowed by CORS'));
         }
     },
-    methods: ['GET', 'POST'],
-    allowedHeaders: ['Content-Type', 'Authorization'],
+    methods: allowedMethods,
+    allowedHeaders,
     credentials: true,
 });
 
-module.exports = { corsMiddleware, allowedOrigins };
+module.exports = {
+    corsMiddleware,
+    allowedOrigins,
+    allowedMethods,
+    allowedHeaders,
+};

--- a/middleware/staticMedia.js
+++ b/middleware/staticMedia.js
@@ -1,0 +1,141 @@
+const path = require('path');
+
+const CONTENT_TYPES = {
+    '.webp': 'image/webp',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.png': 'image/png',
+    '.gif': 'image/gif',
+    '.avif': 'image/avif',
+};
+
+const CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
+const requireObject = (value, name) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error(`${name} must be an object.`);
+    }
+};
+
+const requireFunction = (value, name) => {
+    if (typeof value !== 'function') {
+        throw new Error(`${name} must be a function.`);
+    }
+};
+
+const sendJson = (res, statusCode, payload) => {
+    res.statusCode = statusCode;
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.end(JSON.stringify(payload));
+};
+
+const getRawMediaPath = (req) => {
+    const rawUrl = typeof req.path === 'string' ? req.path : req.url;
+    const rawPath = String(rawUrl || '').split('?')[0];
+
+    if (!rawPath || rawPath === '/') {
+        throw new Error('Invalid media path');
+    }
+
+    return rawPath;
+};
+
+const decodePathSegment = (segment) => {
+    try {
+        return decodeURIComponent(segment);
+    } catch (error) {
+        throw new Error('Invalid media path');
+    }
+};
+
+const getStorageKeyFromRequest = (req) => {
+    const rawPath = getRawMediaPath(req);
+
+    if (rawPath.startsWith('//') || rawPath.includes('\0')) {
+        throw new Error('Invalid media path');
+    }
+
+    const rawSegments = rawPath.replace(/^\/+/, '').split('/');
+    if (rawSegments.length === 0 || rawSegments.some((segment) => segment === '')) {
+        throw new Error('Invalid media path');
+    }
+
+    const segments = rawSegments.map(decodePathSegment);
+    if (segments.some((segment) =>
+        segment === ''
+        || segment === '..'
+        || segment.includes('\\')
+        || segment.includes('\0')
+        || segment.includes('/')
+    )) {
+        throw new Error('Invalid media path');
+    }
+
+    const storageKey = segments.join('/');
+    const extension = path.extname(storageKey).toLowerCase();
+    const contentType = CONTENT_TYPES[extension];
+
+    if (!contentType) {
+        throw new Error('Invalid media path');
+    }
+
+    return {
+        storageKey,
+        contentType,
+    };
+};
+
+function createStaticMediaMiddleware({ storageProvider } = {}) {
+    requireObject(storageProvider, 'storageProvider');
+    requireFunction(storageProvider.objectExists, 'storageProvider.objectExists');
+    requireFunction(storageProvider.createReadStream, 'storageProvider.createReadStream');
+
+    return async function staticMediaMiddleware(req, res, next) {
+        if (req.method !== 'GET' && req.method !== 'HEAD') {
+            next();
+            return;
+        }
+
+        let media;
+        try {
+            media = getStorageKeyFromRequest(req);
+        } catch (error) {
+            sendJson(res, 400, { error: 'Invalid media path' });
+            return;
+        }
+
+        try {
+            const exists = await storageProvider.objectExists(media.storageKey);
+            if (!exists) {
+                sendJson(res, 404, { error: 'Media not found' });
+                return;
+            }
+
+            res.statusCode = 200;
+            res.setHeader('Content-Type', media.contentType);
+            res.setHeader('Cache-Control', CACHE_CONTROL);
+
+            if (req.method === 'HEAD') {
+                res.end();
+                return;
+            }
+
+            const readableStream = storageProvider.createReadStream(media.storageKey);
+            readableStream.on('error', (error) => {
+                if (!res.headersSent) {
+                    next(error);
+                    return;
+                }
+
+                res.destroy(error);
+            });
+            readableStream.pipe(res);
+        } catch (error) {
+            next(error);
+        }
+    };
+}
+
+module.exports = {
+    createStaticMediaMiddleware,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "image-upload-service",
             "version": "1.0.0",
             "dependencies": {
+                "better-sqlite3": "^12.11.1",
                 "cors": "^2.8.5",
                 "dotenv": "^16.4.5",
                 "express": "^4.21.0",
@@ -1364,6 +1365,20 @@
                 }
             ]
         },
+        "node_modules/better-sqlite3": {
+            "version": "12.11.1",
+            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+            "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "bindings": "^1.5.0",
+                "prebuild-install": "^7.1.1"
+            },
+            "engines": {
+                "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+            }
+        },
         "node_modules/bignumber.js": {
             "version": "9.1.2",
             "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
@@ -1371,6 +1386,40 @@
             "optional": true,
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "license": "MIT",
+            "dependencies": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/bl/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/bmp-js": {
@@ -1487,6 +1536,12 @@
             "dependencies": {
                 "follow-redirects": "^1.15.6"
             }
+        },
+        "node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "license": "ISC"
         },
         "node_modules/cliui": {
             "version": "8.0.1",
@@ -1624,6 +1679,30 @@
                 "ms": "2.0.0"
             }
         },
+        "node_modules/decompress-response": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-response": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/define-data-property": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -1756,7 +1835,6 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "optional": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -1815,6 +1893,15 @@
             "version": "0.1.12",
             "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
             "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
+        },
+        "node_modules/expand-template": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+            "license": "(MIT OR WTFPL)",
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/express": {
             "version": "4.21.1",
@@ -1940,6 +2027,12 @@
                 "url": "https://github.com/sindresorhus/file-type?sponsor=1"
             }
         },
+        "node_modules/file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "license": "MIT"
+        },
         "node_modules/finalhandler": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -2028,6 +2121,12 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "license": "MIT"
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -2120,6 +2219,12 @@
                 "image-q": "^4.0.0",
                 "omggif": "^1.0.10"
             }
+        },
+        "node_modules/github-from-package": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+            "license": "MIT"
         },
         "node_modules/global": {
             "version": "4.4.0",
@@ -2419,6 +2524,12 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "license": "ISC"
         },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
@@ -2771,6 +2882,18 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/mimic-response": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/min-document": {
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
@@ -2800,6 +2923,12 @@
                 "mkdirp": "bin/cmd.js"
             }
         },
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "license": "MIT"
+        },
         "node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2823,12 +2952,30 @@
                 "node": ">= 6.0.0"
             }
         },
+        "node_modules/napi-build-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+            "license": "MIT"
+        },
         "node_modules/negotiator": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-abi": {
+            "version": "3.92.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+            "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/node-fetch": {
@@ -2907,7 +3054,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "optional": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -3006,6 +3152,33 @@
                 "node": ">=4.0.0"
             }
         },
+        "node_modules/prebuild-install": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+            "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+            "license": "MIT",
+            "dependencies": {
+                "detect-libc": "^2.0.0",
+                "expand-template": "^2.0.3",
+                "github-from-package": "0.0.0",
+                "minimist": "^1.2.3",
+                "mkdirp-classic": "^0.5.3",
+                "napi-build-utils": "^2.0.0",
+                "node-abi": "^3.3.0",
+                "pump": "^3.0.0",
+                "rc": "^1.2.7",
+                "simple-get": "^4.0.0",
+                "tar-fs": "^2.0.0",
+                "tunnel-agent": "^0.6.0"
+            },
+            "bin": {
+                "prebuild-install": "bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/process": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -3068,6 +3241,16 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/pump": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+            "license": "MIT",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
         "node_modules/qs": {
             "version": "6.13.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -3102,6 +3285,21 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
             }
         },
         "node_modules/readable-stream": {
@@ -3367,6 +3565,51 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/simple-concat": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/simple-get": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decompress-response": "^6.0.0",
+                "once": "^1.3.1",
+                "simple-concat": "^1.0.0"
+            }
+        },
         "node_modules/simple-swizzle": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -3447,6 +3690,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
@@ -3474,6 +3726,48 @@
             "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
             "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
             "optional": true
+        },
+        "node_modules/tar-fs": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+            "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "license": "MIT",
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tar-stream/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
         },
         "node_modules/teeny-request": {
             "version": "9.0.0",
@@ -3596,6 +3890,18 @@
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
             "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+        },
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/type-is": {
             "version": "1.6.18",
@@ -3726,8 +4032,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "optional": true
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/xhr": {
             "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "test": "node --test \"tests/**/*.test.js\""
     },
     "dependencies": {
+        "better-sqlite3": "^12.11.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.21.0",

--- a/repositories/sqliteImageRepository.js
+++ b/repositories/sqliteImageRepository.js
@@ -1,0 +1,369 @@
+const fs = require('fs');
+const path = require('path');
+const Database = require('better-sqlite3');
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 200;
+
+const requireConfig = (config) => {
+    if (!config || typeof config !== 'object') {
+        throw new Error('config is required for SQLite image repository.');
+    }
+    if (!config.sqlitePath) {
+        throw new Error('config.sqlitePath is required for SQLite image repository.');
+    }
+};
+
+const requireNonEmptyString = (value, name) => {
+    if (typeof value !== 'string' || value.trim() === '') {
+        throw new Error(`${name} is required.`);
+    }
+};
+
+const requireBoolean = (value, name) => {
+    if (typeof value !== 'boolean') {
+        throw new Error(`${name} must be a boolean.`);
+    }
+};
+
+const normalizePagination = (options = {}) => {
+    const limit = options.limit === undefined ? DEFAULT_LIMIT : Number(options.limit);
+    const offset = options.offset === undefined ? 0 : Number(options.offset);
+
+    if (!Number.isInteger(limit) || limit <= 0) {
+        throw new Error('limit must be a positive integer.');
+    }
+    if (!Number.isInteger(offset) || offset < 0) {
+        throw new Error('offset must be a non-negative integer.');
+    }
+
+    return {
+        limit: Math.min(limit, MAX_LIMIT),
+        offset,
+    };
+};
+
+const toSqliteBoolean = (value) => (value === false ? 0 : 1);
+
+const nowIso = () => new Date().toISOString();
+
+const mapRowToImage = (row) => {
+    if (!row) return null;
+
+    return {
+        id: row.id,
+        ownerId: row.owner_id,
+        title: row.title,
+        description: row.description,
+        storageKey: row.storage_key,
+        thumbnailKey: row.thumbnail_key,
+        mimeType: row.mime_type,
+        width: row.width,
+        height: row.height,
+        sizeBytes: row.size_bytes,
+        isPublic: Boolean(row.is_public),
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+        deletedAt: row.deleted_at,
+        archivedAt: row.archived_at,
+    };
+};
+
+const ensureColumn = (db, tableName, columnName, columnDefinition) => {
+    const columns = db.prepare(`PRAGMA table_info(${tableName})`).all();
+    const exists = columns.some((column) => column.name === columnName);
+
+    if (!exists) {
+        db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnDefinition}`);
+    }
+};
+
+const initializeSchema = (db) => {
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS images (
+            id TEXT PRIMARY KEY,
+            owner_id TEXT NOT NULL,
+            title TEXT,
+            description TEXT,
+            storage_key TEXT NOT NULL,
+            thumbnail_key TEXT,
+            mime_type TEXT,
+            width INTEGER,
+            height INTEGER,
+            size_bytes INTEGER,
+            is_public INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL,
+            updated_at TEXT,
+            deleted_at TEXT,
+            archived_at TEXT
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_images_public_created
+        ON images (is_public, created_at);
+
+        CREATE INDEX IF NOT EXISTS idx_images_owner_created
+        ON images (owner_id, created_at);
+
+        CREATE INDEX IF NOT EXISTS idx_images_deleted
+        ON images (deleted_at);
+    `);
+
+    ensureColumn(db, 'images', 'archived_at', 'archived_at TEXT');
+
+    db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_images_archived
+        ON images (archived_at);
+    `);
+};
+
+const createSqliteImageRepository = ({ config } = {}) => {
+    requireConfig(config);
+
+    const sqlitePath = path.resolve(config.sqlitePath);
+    fs.mkdirSync(path.dirname(sqlitePath), { recursive: true });
+
+    const db = new Database(sqlitePath);
+    initializeSchema(db);
+
+    const insertImage = db.prepare(`
+        INSERT INTO images (
+            id,
+            owner_id,
+            title,
+            description,
+            storage_key,
+            thumbnail_key,
+            mime_type,
+            width,
+            height,
+            size_bytes,
+            is_public,
+            created_at,
+            updated_at,
+            deleted_at,
+            archived_at
+        ) VALUES (
+            @id,
+            @ownerId,
+            @title,
+            @description,
+            @storageKey,
+            @thumbnailKey,
+            @mimeType,
+            @width,
+            @height,
+            @sizeBytes,
+            @isPublic,
+            @createdAt,
+            @updatedAt,
+            NULL,
+            NULL
+        )
+    `);
+    const findByIdActive = db.prepare('SELECT * FROM images WHERE id = ? AND deleted_at IS NULL');
+    const findByIdAny = db.prepare('SELECT * FROM images WHERE id = ?');
+    const listPublic = db.prepare(`
+        SELECT * FROM images
+        WHERE is_public = 1
+            AND deleted_at IS NULL
+            AND archived_at IS NULL
+        ORDER BY created_at DESC
+        LIMIT @limit OFFSET @offset
+    `);
+    const listByOwnerActive = db.prepare(`
+        SELECT * FROM images
+        WHERE owner_id = @ownerId
+            AND deleted_at IS NULL
+            AND archived_at IS NULL
+        ORDER BY created_at DESC
+        LIMIT @limit OFFSET @offset
+    `);
+    const listByOwnerArchived = db.prepare(`
+        SELECT * FROM images
+        WHERE owner_id = @ownerId
+            AND deleted_at IS NULL
+            AND archived_at IS NOT NULL
+        ORDER BY created_at DESC
+        LIMIT @limit OFFSET @offset
+    `);
+    const listByOwnerAll = db.prepare(`
+        SELECT * FROM images
+        WHERE owner_id = @ownerId
+            AND deleted_at IS NULL
+        ORDER BY created_at DESC
+        LIMIT @limit OFFSET @offset
+    `);
+    const softDelete = db.prepare(`
+        UPDATE images
+        SET deleted_at = @timestamp,
+            updated_at = @timestamp
+        WHERE id = @imageId
+            AND owner_id = @ownerId
+            AND deleted_at IS NULL
+    `);
+    const updateVisibility = db.prepare(`
+        UPDATE images
+        SET is_public = @isPublic,
+            updated_at = @timestamp
+        WHERE id = @imageId
+            AND owner_id = @ownerId
+            AND deleted_at IS NULL
+    `);
+    const archiveImage = db.prepare(`
+        UPDATE images
+        SET archived_at = COALESCE(archived_at, @timestamp),
+            updated_at = @timestamp
+        WHERE id = @imageId
+            AND owner_id = @ownerId
+            AND deleted_at IS NULL
+    `);
+    const unarchiveImage = db.prepare(`
+        UPDATE images
+        SET archived_at = NULL,
+            updated_at = @timestamp
+        WHERE id = @imageId
+            AND owner_id = @ownerId
+            AND deleted_at IS NULL
+    `);
+
+    const createImage = async (imageData = {}) => {
+        requireNonEmptyString(imageData.id, 'id');
+        requireNonEmptyString(imageData.ownerId, 'ownerId');
+        requireNonEmptyString(imageData.storageKey, 'storageKey');
+
+        const createdAt = imageData.createdAt || nowIso();
+        const updatedAt = imageData.updatedAt || createdAt;
+        const params = {
+            id: imageData.id,
+            ownerId: imageData.ownerId,
+            title: imageData.title ?? null,
+            description: imageData.description ?? null,
+            storageKey: imageData.storageKey,
+            thumbnailKey: imageData.thumbnailKey ?? null,
+            mimeType: imageData.mimeType ?? null,
+            width: imageData.width ?? null,
+            height: imageData.height ?? null,
+            sizeBytes: imageData.sizeBytes ?? null,
+            isPublic: toSqliteBoolean(imageData.isPublic),
+            createdAt,
+            updatedAt,
+        };
+
+        try {
+            insertImage.run(params);
+        } catch (error) {
+            if (error.code === 'SQLITE_CONSTRAINT_PRIMARYKEY' || error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+                throw new Error(`Image id already exists: ${imageData.id}`);
+            }
+            throw error;
+        }
+
+        return mapRowToImage(findByIdAny.get(imageData.id));
+    };
+
+    const findImageById = async (imageId, options = {}) => {
+        requireNonEmptyString(imageId, 'imageId');
+        const row = options.includeDeleted === true
+            ? findByIdAny.get(imageId)
+            : findByIdActive.get(imageId);
+
+        return mapRowToImage(row);
+    };
+
+    const listPublicImages = async (options = {}) => {
+        const pagination = normalizePagination(options);
+        return listPublic.all(pagination).map(mapRowToImage);
+    };
+
+    const listImagesByOwner = async (ownerId, options = {}) => {
+        requireNonEmptyString(ownerId, 'ownerId');
+        const pagination = normalizePagination(options);
+        const statement = options.archived === true
+            ? listByOwnerArchived
+            : options.includeArchived === true
+                ? listByOwnerAll
+                : listByOwnerActive;
+
+        return statement.all({ ownerId, ...pagination }).map(mapRowToImage);
+    };
+
+    const updateImageVisibility = async (imageId, ownerId, isPublic) => {
+        requireNonEmptyString(imageId, 'imageId');
+        requireNonEmptyString(ownerId, 'ownerId');
+        requireBoolean(isPublic, 'isPublic');
+
+        const result = updateVisibility.run({
+            imageId,
+            ownerId,
+            isPublic: toSqliteBoolean(isPublic),
+            timestamp: nowIso(),
+        });
+
+        if (result.changes !== 1) return null;
+        return mapRowToImage(findByIdActive.get(imageId));
+    };
+
+    const archiveImageById = async (imageId, ownerId) => {
+        requireNonEmptyString(imageId, 'imageId');
+        requireNonEmptyString(ownerId, 'ownerId');
+
+        const result = archiveImage.run({
+            imageId,
+            ownerId,
+            timestamp: nowIso(),
+        });
+
+        if (result.changes !== 1) return null;
+        return mapRowToImage(findByIdActive.get(imageId));
+    };
+
+    const unarchiveImageById = async (imageId, ownerId) => {
+        requireNonEmptyString(imageId, 'imageId');
+        requireNonEmptyString(ownerId, 'ownerId');
+
+        const result = unarchiveImage.run({
+            imageId,
+            ownerId,
+            timestamp: nowIso(),
+        });
+
+        if (result.changes !== 1) return null;
+        return mapRowToImage(findByIdActive.get(imageId));
+    };
+
+    const deleteImageById = async (imageId, ownerId) => {
+        requireNonEmptyString(imageId, 'imageId');
+        requireNonEmptyString(ownerId, 'ownerId');
+
+        const result = softDelete.run({
+            imageId,
+            ownerId,
+            timestamp: nowIso(),
+        });
+
+        return {
+            imageId,
+            deleted: result.changes === 1,
+        };
+    };
+
+    const close = async () => {
+        db.close();
+    };
+
+    return {
+        listPublicImages,
+        listImagesByOwner,
+        findImageById,
+        createImage,
+        updateImageVisibility,
+        archiveImageById,
+        unarchiveImageById,
+        deleteImageById,
+        close,
+    };
+};
+
+module.exports = {
+    createSqliteImageRepository,
+};

--- a/routes/imageApiRoutes.js
+++ b/routes/imageApiRoutes.js
@@ -1,0 +1,49 @@
+const express = require('express');
+
+const { createImageApiController } = require('../controllers/imageApiController');
+const { withSemaphore } = require('../utils/semaphore');
+
+const passThrough = (req, res, next) => next();
+
+function createImageApiRoutes({
+    imageService,
+    imageUploadService,
+    authProvider,
+    heavyLimiter,
+    multipartSizeGuard,
+    upload,
+    resizeSemaphore,
+} = {}) {
+    const controller = createImageApiController({
+        imageService,
+        imageUploadService,
+        authProvider,
+    });
+    const router = express.Router();
+    const uploadSingleImage = upload && typeof upload.single === 'function'
+        ? upload.single('image')
+        : passThrough;
+    const uploadHandler = resizeSemaphore
+        ? withSemaphore(resizeSemaphore, controller.uploadImage)
+        : controller.uploadImage;
+
+    router.post(
+        '/',
+        heavyLimiter || passThrough,
+        multipartSizeGuard || passThrough,
+        uploadSingleImage,
+        uploadHandler,
+    );
+    router.get('/public', controller.listPublicImages);
+    router.get('/me', controller.listMyImages);
+    router.patch('/:imageId/visibility', express.json({ limit: '2kb' }), controller.updateImageVisibility);
+    router.post('/:imageId/archive', controller.archiveImage);
+    router.post('/:imageId/unarchive', controller.unarchiveImage);
+    router.delete('/:imageId', controller.deleteImage);
+
+    return router;
+}
+
+module.exports = {
+    createImageApiRoutes,
+};

--- a/services/imagePresenter.js
+++ b/services/imagePresenter.js
@@ -1,0 +1,88 @@
+const requireObject = (value, name) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error(`${name} must be an object.`);
+    }
+    return value;
+};
+
+const requireNonEmptyString = (value, name) => {
+    if (typeof value !== 'string' || value.trim() === '') {
+        throw new Error(`${name} is required.`);
+    }
+};
+
+const assignIfPresent = (target, key, value) => {
+    if (value !== null && value !== undefined) {
+        target[key] = value;
+    }
+};
+
+const createUrlOptions = (imageRecord, kind) => ({
+    visibility: Boolean(imageRecord.isPublic) ? 'public' : 'private',
+    kind,
+});
+
+function createImagePresenter({ storageProvider } = {}) {
+    requireObject(storageProvider, 'storageProvider');
+    if (typeof storageProvider.getUrl !== 'function') {
+        throw new Error('storageProvider.getUrl must be a function.');
+    }
+
+    const toImageDto = async (imageRecord, options = {}) => {
+        requireObject(imageRecord, 'imageRecord');
+        requireNonEmptyString(imageRecord.id, 'imageRecord.id');
+        requireNonEmptyString(imageRecord.storageKey, 'imageRecord.storageKey');
+        requireNonEmptyString(imageRecord.createdAt, 'imageRecord.createdAt');
+
+        const isPublic = Boolean(imageRecord.isPublic);
+        const imageUrl = await storageProvider.getUrl(imageRecord.storageKey, createUrlOptions(imageRecord, 'image'));
+        const dto = {
+            id: imageRecord.id,
+        };
+
+        assignIfPresent(dto, 'ownerId', imageRecord.ownerId);
+        assignIfPresent(dto, 'title', imageRecord.title);
+        assignIfPresent(dto, 'description', imageRecord.description);
+        dto.imageUrl = imageUrl;
+
+        if (imageRecord.thumbnailKey) {
+            dto.thumbnailUrl = await storageProvider.getUrl(
+                imageRecord.thumbnailKey,
+                createUrlOptions(imageRecord, 'thumbnail'),
+            );
+        }
+
+        assignIfPresent(dto, 'width', imageRecord.width);
+        assignIfPresent(dto, 'height', imageRecord.height);
+        assignIfPresent(dto, 'sizeBytes', imageRecord.sizeBytes);
+        assignIfPresent(dto, 'mimeType', imageRecord.mimeType);
+        dto.isPublic = isPublic;
+        dto.isArchived = Boolean(imageRecord.archivedAt);
+        dto.createdAt = imageRecord.createdAt;
+        assignIfPresent(dto, 'updatedAt', imageRecord.updatedAt);
+        assignIfPresent(dto, 'archivedAt', imageRecord.archivedAt);
+
+        return dto;
+    };
+
+    const toImageDtos = async (imageRecords, options = {}) => {
+        if (!Array.isArray(imageRecords)) {
+            throw new Error('imageRecords must be an array.');
+        }
+
+        const dtos = [];
+        for (const imageRecord of imageRecords) {
+            dtos.push(await toImageDto(imageRecord, options));
+        }
+        return dtos;
+    };
+
+    return {
+        toImageDto,
+        toImageDtos,
+    };
+}
+
+module.exports = {
+    createImagePresenter,
+};

--- a/services/imageProcessor.js
+++ b/services/imageProcessor.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+
+const getSharp = () => require('sharp');
+const getJimp = () => require('jimp');
+
+const requireFilePath = (file) => {
+    if (!file || typeof file.path !== 'string' || file.path.trim() === '') {
+        throw new Error('file.path is required for image processing.');
+    }
+};
+
+function createImageProcessor({ processorName } = {}) {
+    const selectedProcessor = processorName || 'sharp';
+
+    const processWithSharp = async (file, options) => {
+        const sharp = getSharp();
+        const { data, info } = await sharp(file.path)
+            .rotate()
+            .resize(options.maxWidth)
+            .jpeg({ quality: options.quality })
+            .toBuffer({ resolveWithObject: true });
+
+        return {
+            buffer: data,
+            mimeType: 'image/jpeg',
+            extension: 'jpg',
+            width: info.width,
+            height: info.height,
+            sizeBytes: data.length,
+        };
+    };
+
+    const processWithJimp = async (file, options) => {
+        const Jimp = getJimp();
+        const image = await Jimp.read(file.path);
+        image.resize(options.maxWidth, Jimp.AUTO);
+        image.quality(options.quality);
+        const buffer = await image.getBufferAsync(Jimp.MIME_JPEG);
+
+        return {
+            buffer,
+            mimeType: 'image/jpeg',
+            extension: 'jpg',
+            width: image.bitmap.width,
+            height: image.bitmap.height,
+            sizeBytes: buffer.length,
+        };
+    };
+
+    const processImage = async (file, options = {}) => {
+        requireFilePath(file);
+
+        const processorOptions = {
+            maxWidth: options.maxWidth || 1440,
+            quality: options.quality || 80,
+        };
+
+        if (selectedProcessor === 'jimp') {
+            return processWithJimp(file, processorOptions);
+        }
+
+        return processWithSharp(file, processorOptions);
+    };
+
+    return {
+        processImage,
+    };
+}
+
+const cleanTempFile = async (filePath) => {
+    if (!filePath) return;
+    await fs.promises.unlink(filePath).catch(() => {});
+};
+
+module.exports = {
+    createImageProcessor,
+    cleanTempFile,
+};

--- a/services/imageService.js
+++ b/services/imageService.js
@@ -1,0 +1,182 @@
+const VALIDATION_ERROR = 'VALIDATION_ERROR';
+const UNAUTHENTICATED = 'UNAUTHENTICATED';
+const FORBIDDEN = 'FORBIDDEN';
+
+const createHttpError = (message, statusCode, code) => {
+    const error = new Error(message);
+    error.statusCode = statusCode;
+    error.code = code;
+    return error;
+};
+
+const createValidationError = (message) => createHttpError(message, 400, VALIDATION_ERROR);
+
+const createUnauthenticatedError = (message) => createHttpError(message, 401, UNAUTHENTICATED);
+
+const createForbiddenError = (message) => createHttpError(message, 403, FORBIDDEN);
+
+const requireObject = (value, name) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error(`${name} must be an object.`);
+    }
+    return value;
+};
+
+const requireFunction = (value, name) => {
+    if (typeof value !== 'function') {
+        throw new Error(`${name} must be a function.`);
+    }
+};
+
+const requireNonEmptyString = (value, name) => {
+    if (typeof value !== 'string' || value.trim() === '') {
+        throw createValidationError(`${name} is required.`);
+    }
+};
+
+const requireBoolean = (value, name) => {
+    if (typeof value !== 'boolean') {
+        throw createValidationError(`${name} must be a boolean.`);
+    }
+};
+
+const requireCurrentUser = (currentUser) => {
+    if (!currentUser || typeof currentUser.uid !== 'string' || currentUser.uid.trim() === '') {
+        throw createUnauthenticatedError('Authenticated currentUser.uid is required.');
+    }
+    return currentUser;
+};
+
+function createImageService({
+    imageRepository,
+    storageProvider,
+    imagePresenter,
+} = {}) {
+    requireObject(imageRepository, 'imageRepository');
+    requireObject(storageProvider, 'storageProvider');
+    requireObject(imagePresenter, 'imagePresenter');
+
+    requireFunction(imageRepository.listPublicImages, 'imageRepository.listPublicImages');
+    requireFunction(imageRepository.listImagesByOwner, 'imageRepository.listImagesByOwner');
+    requireFunction(imageRepository.findImageById, 'imageRepository.findImageById');
+    requireFunction(imageRepository.createImage, 'imageRepository.createImage');
+    requireFunction(imageRepository.updateImageVisibility, 'imageRepository.updateImageVisibility');
+    requireFunction(imageRepository.archiveImageById, 'imageRepository.archiveImageById');
+    requireFunction(imageRepository.unarchiveImageById, 'imageRepository.unarchiveImageById');
+    requireFunction(imageRepository.deleteImageById, 'imageRepository.deleteImageById');
+    requireFunction(storageProvider.deleteObject, 'storageProvider.deleteObject');
+    requireFunction(imagePresenter.toImageDto, 'imagePresenter.toImageDto');
+    requireFunction(imagePresenter.toImageDtos, 'imagePresenter.toImageDtos');
+
+    const listPublicImages = async (options = {}) => {
+        const imageRecords = await imageRepository.listPublicImages(options);
+        return imagePresenter.toImageDtos(imageRecords);
+    };
+
+    const listUserImages = async (currentUser, options = {}) => {
+        const user = requireCurrentUser(currentUser);
+        const imageRecords = await imageRepository.listImagesByOwner(user.uid, options);
+        return imagePresenter.toImageDtos(imageRecords);
+    };
+
+    const findImageById = async (imageId, options = {}) => {
+        requireNonEmptyString(imageId, 'imageId');
+
+        const imageRecord = await imageRepository.findImageById(imageId, options);
+        if (!imageRecord) return null;
+
+        return imagePresenter.toImageDto(imageRecord);
+    };
+
+    const createImage = async (imageData, currentUser) => {
+        const user = requireCurrentUser(currentUser);
+        if (!imageData || typeof imageData !== 'object' || Array.isArray(imageData)) {
+            throw createValidationError('imageData is required.');
+        }
+        requireNonEmptyString(imageData.id, 'imageData.id');
+        requireNonEmptyString(imageData.storageKey, 'imageData.storageKey');
+
+        const repositoryImageData = {
+            ...imageData,
+            ownerId: user.uid,
+        };
+        const imageRecord = await imageRepository.createImage(repositoryImageData);
+        return imagePresenter.toImageDto(imageRecord);
+    };
+
+    const updateImageVisibility = async (imageId, currentUser, isPublic) => {
+        requireNonEmptyString(imageId, 'imageId');
+        const user = requireCurrentUser(currentUser);
+        requireBoolean(isPublic, 'isPublic');
+
+        const imageRecord = await imageRepository.updateImageVisibility(imageId, user.uid, isPublic);
+        if (!imageRecord) return null;
+
+        return imagePresenter.toImageDto(imageRecord);
+    };
+
+    const archiveImage = async (imageId, currentUser) => {
+        requireNonEmptyString(imageId, 'imageId');
+        const user = requireCurrentUser(currentUser);
+
+        const imageRecord = await imageRepository.archiveImageById(imageId, user.uid);
+        if (!imageRecord) return null;
+
+        return imagePresenter.toImageDto(imageRecord);
+    };
+
+    const unarchiveImage = async (imageId, currentUser) => {
+        requireNonEmptyString(imageId, 'imageId');
+        const user = requireCurrentUser(currentUser);
+
+        const imageRecord = await imageRepository.unarchiveImageById(imageId, user.uid);
+        if (!imageRecord) return null;
+
+        return imagePresenter.toImageDto(imageRecord);
+    };
+
+    const deleteImage = async (imageId, currentUser) => {
+        requireNonEmptyString(imageId, 'imageId');
+        const user = requireCurrentUser(currentUser);
+
+        const imageRecord = await imageRepository.findImageById(imageId);
+        if (!imageRecord) {
+            return {
+                imageId,
+                deleted: false,
+            };
+        }
+
+        if (imageRecord.ownerId !== user.uid) {
+            throw createForbiddenError('Current user does not own this image.');
+        }
+
+        requireNonEmptyString(imageRecord.storageKey, 'imageRecord.storageKey');
+
+        await storageProvider.deleteObject(imageRecord.storageKey);
+        if (imageRecord.thumbnailKey) {
+            await storageProvider.deleteObject(imageRecord.thumbnailKey);
+        }
+
+        const repositoryResult = await imageRepository.deleteImageById(imageId, user.uid);
+        return {
+            imageId,
+            deleted: Boolean(repositoryResult && repositoryResult.deleted),
+        };
+    };
+
+    return {
+        listPublicImages,
+        listUserImages,
+        findImageById,
+        createImage,
+        updateImageVisibility,
+        archiveImage,
+        unarchiveImage,
+        deleteImage,
+    };
+}
+
+module.exports = {
+    createImageService,
+};

--- a/services/imageUploadService.js
+++ b/services/imageUploadService.js
@@ -1,0 +1,271 @@
+const { v4: uuid } = require('uuid');
+
+const { cleanTempFile } = require('./imageProcessor');
+
+const VALIDATION_ERROR = 'VALIDATION_ERROR';
+const UNAUTHENTICATED = 'UNAUTHENTICATED';
+
+const ALLOWED_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'webp', 'avif']);
+
+const createHttpError = (message, statusCode, code) => {
+    const error = new Error(message);
+    error.statusCode = statusCode;
+    error.code = code;
+    return error;
+};
+
+const createValidationError = (message) => createHttpError(message, 400, VALIDATION_ERROR);
+
+const createUnauthenticatedError = (message) => createHttpError(message, 401, UNAUTHENTICATED);
+
+const requireObject = (value, name) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error(`${name} must be an object.`);
+    }
+    return value;
+};
+
+const requireFunction = (value, name) => {
+    if (typeof value !== 'function') {
+        throw new Error(`${name} must be a function.`);
+    }
+};
+
+const requireCurrentUser = (currentUser) => {
+    if (!currentUser || typeof currentUser.uid !== 'string' || currentUser.uid.trim() === '') {
+        throw createUnauthenticatedError('Authenticated currentUser.uid is required.');
+    }
+    return currentUser;
+};
+
+const requireImageFile = (file, config) => {
+    if (!file || typeof file !== 'object' || Array.isArray(file)) {
+        throw createValidationError('file is required.');
+    }
+    if (!file.mimetype || !file.mimetype.startsWith('image/')) {
+        throw createValidationError('file must be an image.');
+    }
+    if (!file.size || file.size <= 0) {
+        throw createValidationError('file must not be empty.');
+    }
+    if (config.maxFileSizeBytes && file.size > config.maxFileSizeBytes) {
+        throw createValidationError('file exceeds maxFileSizeBytes.');
+    }
+};
+
+const normalizePathSegment = (value, name) => {
+    if (typeof value !== 'string' || value.trim() === '') {
+        throw createValidationError(`${name} is required.`);
+    }
+    if (
+        value.includes('/')
+        || value.includes('\\')
+        || value.includes('\0')
+        || value === '.'
+        || value === '..'
+    ) {
+        throw createValidationError(`${name} contains invalid path characters.`);
+    }
+    return value;
+};
+
+const normalizeExtension = (extension) => {
+    if (typeof extension !== 'string' || extension.trim() === '') {
+        throw createValidationError('processed image extension is required.');
+    }
+
+    const normalizedExtension = extension.trim().toLowerCase().replace(/^\./, '');
+    if (!ALLOWED_EXTENSIONS.has(normalizedExtension)) {
+        throw createValidationError(`Unsupported processed image extension: ${extension}`);
+    }
+
+    return normalizedExtension;
+};
+
+const createProcessedKey = (prefix, key) => {
+    if (!prefix) return key;
+    return `${prefix}${key.charAt(0).toUpperCase()}${key.slice(1)}`;
+};
+
+const hasOutput = (processed, prefix = '') => {
+    const bufferKey = createProcessedKey(prefix, 'buffer');
+    const readableStreamKey = createProcessedKey(prefix, 'readableStream');
+    return Boolean(processed[bufferKey] || processed[readableStreamKey]);
+};
+
+const createStorageInput = ({ storageKey, processed, prefix = '' }) => {
+    const bufferKey = createProcessedKey(prefix, 'buffer');
+    const readableStreamKey = createProcessedKey(prefix, 'readableStream');
+
+    return {
+        storageKey,
+        buffer: processed[bufferKey],
+        readableStream: processed[readableStreamKey],
+    };
+};
+
+const getSizeBytes = (processed, saveResult, prefix = '') => {
+    const sizeKey = createProcessedKey(prefix, 'sizeBytes');
+    const bufferKey = createProcessedKey(prefix, 'buffer');
+
+    if (Number.isInteger(processed[sizeKey]) && processed[sizeKey] >= 0) {
+        return processed[sizeKey];
+    }
+    if (Buffer.isBuffer(processed[bufferKey])) {
+        return processed[bufferKey].length;
+    }
+    if (saveResult && Number.isInteger(saveResult.sizeBytes)) {
+        return saveResult.sizeBytes;
+    }
+    return null;
+};
+
+const parseOptionalString = (fields, name) => {
+    const value = fields[name];
+    if (value === undefined || value === null) return undefined;
+    if (Array.isArray(value)) {
+        throw createValidationError(`${name} must be a string.`);
+    }
+    return String(value);
+};
+
+const parseIsPublic = (fields) => {
+    const value = fields.isPublic;
+    if (value === undefined || value === null || value === '') return true;
+    if (value === true || value === 'true') return true;
+    if (value === false || value === 'false') return false;
+    throw createValidationError('isPublic must be true or false.');
+};
+
+const createCleanupRecorder = (storageProvider) => async (storageKeys, originalError) => {
+    if (typeof storageProvider.deleteObject !== 'function') {
+        return;
+    }
+
+    const cleanupFailures = [];
+    for (const storageKey of storageKeys.filter(Boolean)) {
+        try {
+            await storageProvider.deleteObject(storageKey);
+        } catch (cleanupError) {
+            cleanupFailures.push(cleanupError);
+        }
+    }
+
+    if (cleanupFailures.length > 0) {
+        originalError.cleanupFailed = true;
+        originalError.cleanupErrorCount = cleanupFailures.length;
+    }
+};
+
+function createImageUploadService({
+    config,
+    storageProvider,
+    imageService,
+    imageProcessor,
+    idGenerator,
+} = {}) {
+    requireObject(config, 'config');
+    requireObject(storageProvider, 'storageProvider');
+    requireObject(imageService, 'imageService');
+
+    requireFunction(storageProvider.saveObject, 'storageProvider.saveObject');
+    requireFunction(imageService.createImage, 'imageService.createImage');
+
+    const processImage = typeof imageProcessor === 'function'
+        ? imageProcessor
+        : imageProcessor && imageProcessor.processImage;
+    requireFunction(processImage, 'imageProcessor.processImage');
+
+    const generateId = idGenerator || uuid;
+    requireFunction(generateId, 'idGenerator');
+
+    const cleanupSavedObjects = createCleanupRecorder(storageProvider);
+
+    const uploadImage = async ({ file, currentUser, fields = {} } = {}) => {
+        const user = requireCurrentUser(currentUser);
+        requireImageFile(file, config);
+
+        try {
+            const uid = normalizePathSegment(user.uid, 'currentUser.uid');
+            const imageId = normalizePathSegment(String(generateId()), 'imageId');
+            const uploadFields = fields || {};
+            const title = parseOptionalString(uploadFields, 'title');
+            const description = parseOptionalString(uploadFields, 'description');
+            const isPublic = parseIsPublic(uploadFields);
+            const savedStorageKeys = [];
+
+            const processed = await processImage(file, {
+                config,
+                maxWidth: 1440,
+                quality: 80,
+                imageProcessor: config.imageProcessor,
+                maxFileSizeBytes: config.maxFileSizeBytes,
+                lowMemoryMode: config.lowMemoryMode,
+            });
+
+            requireObject(processed, 'processed image');
+            if (!hasOutput(processed)) {
+                throw createValidationError('processed image output is required.');
+            }
+
+            const extension = normalizeExtension(processed.extension || 'jpg');
+            const storageKey = `users/${uid}/images/${imageId}.${extension}`;
+            const thumbnailExtension = processed.thumbnailExtension
+                ? normalizeExtension(processed.thumbnailExtension)
+                : extension;
+            const thumbnailKey = hasOutput(processed, 'thumbnail')
+                ? `users/${uid}/thumbnails/${imageId}.${thumbnailExtension}`
+                : null;
+
+            const mainSaveResult = await storageProvider.saveObject(createStorageInput({
+                storageKey,
+                processed,
+            }));
+            savedStorageKeys.push(storageKey);
+
+            if (thumbnailKey) {
+                try {
+                    await storageProvider.saveObject(createStorageInput({
+                        storageKey: thumbnailKey,
+                        processed,
+                        prefix: 'thumbnail',
+                    }));
+                    savedStorageKeys.push(thumbnailKey);
+                } catch (error) {
+                    await cleanupSavedObjects([storageKey], error);
+                    throw error;
+                }
+            }
+
+            const imageData = {
+                id: imageId,
+                title,
+                description,
+                storageKey,
+                thumbnailKey,
+                mimeType: processed.mimeType || 'image/jpeg',
+                width: processed.width ?? null,
+                height: processed.height ?? null,
+                sizeBytes: getSizeBytes(processed, mainSaveResult),
+                isPublic,
+            };
+
+            try {
+                return await imageService.createImage(imageData, user);
+            } catch (error) {
+                await cleanupSavedObjects(savedStorageKeys, error);
+                throw error;
+            }
+        } finally {
+            await cleanTempFile(file.path);
+        }
+    };
+
+    return {
+        uploadImage,
+    };
+}
+
+module.exports = {
+    createImageUploadService,
+};

--- a/storage/localStorageProvider.js
+++ b/storage/localStorageProvider.js
@@ -1,0 +1,134 @@
+const fs = require('fs/promises');
+const fsSync = require('fs');
+const path = require('path');
+const { pipeline } = require('stream/promises');
+
+const requireConfig = (config) => {
+    if (!config || typeof config !== 'object') {
+        throw new Error('config is required for local storage provider.');
+    }
+    if (!config.localStorageRoot) {
+        throw new Error('config.localStorageRoot is required for local storage provider.');
+    }
+    if (!config.publicMediaBaseUrl) {
+        throw new Error('config.publicMediaBaseUrl is required for local storage provider.');
+    }
+};
+
+const validateStorageKey = (storageKey) => {
+    if (typeof storageKey !== 'string' || storageKey.length === 0) {
+        throw new Error('Invalid storage key: storageKey is required.');
+    }
+    if (storageKey.includes('\0')) {
+        throw new Error('Invalid storage key: null bytes are not allowed.');
+    }
+    if (path.isAbsolute(storageKey)) {
+        throw new Error('Invalid storage key: absolute paths are not allowed.');
+    }
+    if (storageKey.includes('\\')) {
+        throw new Error('Invalid storage key: backslashes are not allowed.');
+    }
+    if (storageKey.endsWith('/')) {
+        throw new Error('Invalid storage key: keys must not end with /.');
+    }
+
+    const segments = storageKey.split('/');
+    if (segments.some((segment) => segment === '..')) {
+        throw new Error('Invalid storage key: .. path segments are not allowed.');
+    }
+};
+
+const resolveObjectPath = (rootPath, storageKey) => {
+    validateStorageKey(storageKey);
+
+    const objectPath = path.resolve(rootPath, storageKey);
+    if (objectPath !== rootPath && !objectPath.startsWith(rootPath + path.sep)) {
+        throw new Error('Invalid storage key: path escapes LOCAL_STORAGE_ROOT.');
+    }
+
+    return objectPath;
+};
+
+const encodeStorageKeyForUrl = (storageKey) =>
+    storageKey.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+
+const pathExistsAsFile = async (filePath) => {
+    try {
+        const stats = await fs.stat(filePath);
+        return stats.isFile();
+    } catch (error) {
+        if (error.code === 'ENOENT') return false;
+        throw error;
+    }
+};
+
+const createLocalStorageProvider = ({ config } = {}) => {
+    requireConfig(config);
+
+    const rootPath = path.resolve(config.localStorageRoot);
+    const publicMediaBaseUrl = config.publicMediaBaseUrl.replace(/\/+$/, '');
+
+    const saveObject = async ({ storageKey, readableStream, buffer, overwrite } = {}) => {
+        if (!readableStream && !buffer) {
+            throw new Error('Either readableStream or buffer is required to save an object.');
+        }
+
+        const objectPath = resolveObjectPath(rootPath, storageKey);
+        const exists = await pathExistsAsFile(objectPath);
+        if (exists && overwrite !== true) {
+            throw new Error(`Object already exists for storageKey: ${storageKey}`);
+        }
+
+        await fs.mkdir(path.dirname(objectPath), { recursive: true });
+
+        if (readableStream) {
+            await pipeline(readableStream, fsSync.createWriteStream(objectPath, { flags: overwrite === true ? 'w' : 'wx' }));
+        } else {
+            await fs.writeFile(objectPath, buffer, { flag: overwrite === true ? 'w' : 'wx' });
+        }
+
+        const stats = await fs.stat(objectPath);
+        return {
+            storageKey,
+            sizeBytes: stats.size,
+        };
+    };
+
+    const deleteObject = async (storageKey) => {
+        const objectPath = resolveObjectPath(rootPath, storageKey);
+        const exists = await pathExistsAsFile(objectPath);
+        if (!exists) {
+            return { storageKey, deleted: false };
+        }
+
+        await fs.unlink(objectPath);
+        return { storageKey, deleted: true };
+    };
+
+    const getUrl = (storageKey) => {
+        validateStorageKey(storageKey);
+        return `${publicMediaBaseUrl}/${encodeStorageKeyForUrl(storageKey)}`;
+    };
+
+    const createReadStream = (storageKey) => {
+        const objectPath = resolveObjectPath(rootPath, storageKey);
+        return fsSync.createReadStream(objectPath);
+    };
+
+    const objectExists = async (storageKey) => {
+        const objectPath = resolveObjectPath(rootPath, storageKey);
+        return pathExistsAsFile(objectPath);
+    };
+
+    return {
+        saveObject,
+        deleteObject,
+        getUrl,
+        createReadStream,
+        objectExists,
+    };
+};
+
+module.exports = {
+    createLocalStorageProvider,
+};

--- a/tests/appComposition.test.js
+++ b/tests/appComposition.test.js
@@ -1,0 +1,584 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { Readable } = require('node:stream');
+
+const originalEnv = process.env;
+process.env = {
+    ...originalEnv,
+    FIREBASE_SERVICE_ACCOUNT_PATH: '/tmp/fake-service-account.json',
+};
+
+const appModule = require('../app');
+const { createImageRouter } = require('../routes/imageRoutes');
+
+process.env = originalEnv;
+
+const createFakeContainer = (overrides = {}) => {
+    const calls = [];
+    const fakeStorageProvider = overrides.storageProvider || {
+        objectExists: async (storageKey) => {
+            calls.push({ method: 'objectExists', storageKey });
+            return storageKey === 'users/user-1/images/image-1.webp';
+        },
+        createReadStream: (storageKey) => {
+            calls.push({ method: 'createReadStream', storageKey });
+            return Readable.from([`content:${storageKey}`]);
+        },
+        getUrl: (storageKey) => `http://localhost:3000/media/${storageKey}`,
+        deleteObject: async (storageKey) => ({ storageKey, deleted: true }),
+    };
+    const fakeAuthProvider = {
+        getCurrentUser: async () => null,
+        requireUser: async (req) => {
+            calls.push({ method: 'requireUser', req });
+            if (overrides.authError) {
+                throw overrides.authError;
+            }
+            return { uid: 'user-1' };
+        },
+    };
+    const fakeImageService = {
+        listPublicImages: async (options) => {
+            calls.push({ method: 'listPublicImages', options });
+            if (overrides.listPublicImagesError) {
+                throw overrides.listPublicImagesError;
+            }
+            return [
+                {
+                    id: 'public-image-1',
+                    imageUrl: 'http://localhost/media/public-image-1.webp',
+                    isPublic: true,
+                    createdAt: '2026-01-01T00:00:00.000Z',
+                },
+            ];
+        },
+        listUserImages: async (currentUser, options) => {
+            calls.push({ method: 'listUserImages', currentUser, options });
+            return [
+                {
+                    id: 'user-image-1',
+                    imageUrl: 'http://localhost/media/user-image-1.webp',
+                    isPublic: false,
+                    createdAt: '2026-01-01T00:00:00.000Z',
+                },
+            ];
+        },
+        deleteImage: async (imageId, currentUser) => {
+            calls.push({ method: 'deleteImage', imageId, currentUser });
+            return {
+                imageId,
+                deleted: true,
+            };
+        },
+        updateImageVisibility: async (imageId, currentUser, isPublic) => {
+            calls.push({ method: 'updateImageVisibility', imageId, currentUser, isPublic });
+            return {
+                id: imageId,
+                imageUrl: `http://localhost/media/${imageId}.webp`,
+                isPublic,
+                isArchived: false,
+                createdAt: '2026-01-01T00:00:00.000Z',
+            };
+        },
+        archiveImage: async (imageId, currentUser) => {
+            calls.push({ method: 'archiveImage', imageId, currentUser });
+            return {
+                id: imageId,
+                imageUrl: `http://localhost/media/${imageId}.webp`,
+                isPublic: false,
+                isArchived: true,
+                archivedAt: '2026-01-02T00:00:00.000Z',
+                createdAt: '2026-01-01T00:00:00.000Z',
+            };
+        },
+        unarchiveImage: async (imageId, currentUser) => {
+            calls.push({ method: 'unarchiveImage', imageId, currentUser });
+            return {
+                id: imageId,
+                imageUrl: `http://localhost/media/${imageId}.webp`,
+                isPublic: false,
+                isArchived: false,
+                createdAt: '2026-01-01T00:00:00.000Z',
+            };
+        },
+    };
+    const fakeImageUploadService = {
+        uploadImage: async ({ file, currentUser, fields }) => {
+            calls.push({ method: 'uploadImage', file, currentUser, fields });
+            return {
+                id: 'uploaded-image-1',
+                imageUrl: 'http://localhost/media/uploaded-image-1.webp',
+                isPublic: true,
+                createdAt: '2026-01-01T00:00:00.000Z',
+            };
+        },
+    };
+
+    return {
+        calls,
+        config: {
+            storageProvider: overrides.storageProviderName || 'firebase',
+        },
+        storageProvider: fakeStorageProvider,
+        authProvider: fakeAuthProvider,
+        imageService: fakeImageService,
+        imageUploadService: fakeImageUploadService,
+    };
+};
+
+const getCreateApp = () => appModule.createApp || appModule;
+
+const parseHeaderList = (value) => String(value || '')
+    .split(',')
+    .map((item) => item.trim().toLowerCase())
+    .filter(Boolean);
+
+const request = async (app, options) => {
+    const server = http.createServer(app);
+
+    await new Promise((resolve) => server.listen(0, resolve));
+    const { port } = server.address();
+
+    try {
+        return await new Promise((resolve, reject) => {
+            const req = http.request({
+                hostname: '127.0.0.1',
+                port,
+                path: options.path,
+                method: options.method || 'GET',
+                headers: options.headers || {},
+            }, (res) => {
+                let body = '';
+                res.setEncoding('utf8');
+                res.on('data', (chunk) => {
+                    body += chunk;
+                });
+                res.on('end', () => {
+                    resolve({
+                        statusCode: res.statusCode,
+                        headers: res.headers,
+                        body,
+                        json: body && res.headers['content-type'] && res.headers['content-type'].includes('application/json')
+                            ? JSON.parse(body)
+                            : null,
+                    });
+                });
+            });
+
+            req.on('error', reject);
+            req.end(options.body || undefined);
+        });
+    } finally {
+        await new Promise((resolve) => server.close(resolve));
+    }
+};
+
+test('app module still exports a usable app factory according to existing project expectations', () => {
+    assert.equal(typeof appModule.createApp, 'function');
+});
+
+test('createApp({ container }) creates an Express app', () => {
+    const createApp = getCreateApp();
+    const app = createApp({ container: createFakeContainer() });
+
+    assert.equal(typeof app, 'function');
+    assert.equal(typeof app.use, 'function');
+});
+
+test('mounted app responds to GET /images/public', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, { path: '/images/public' });
+
+    assert.notEqual(response.statusCode, 404);
+});
+
+test('GET /images/public returns status 200', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, { path: '/images/public' });
+
+    assert.equal(response.statusCode, 200);
+});
+
+test('GET /images/public returns { images }', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, { path: '/images/public' });
+
+    assert.deepEqual(response.json, {
+        images: [
+            {
+                id: 'public-image-1',
+                imageUrl: 'http://localhost/media/public-image-1.webp',
+                isPublic: true,
+                createdAt: '2026-01-01T00:00:00.000Z',
+            },
+        ],
+    });
+});
+
+test('mounted app responds to GET /images/me', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, { path: '/images/me' });
+
+    assert.notEqual(response.statusCode, 404);
+});
+
+test('GET /images/me returns status 200 when fake auth succeeds', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, { path: '/images/me' });
+
+    assert.equal(response.statusCode, 200);
+});
+
+test('GET /images/me returns { images }', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, { path: '/images/me' });
+
+    assert.deepEqual(response.json, {
+        images: [
+            {
+                id: 'user-image-1',
+                imageUrl: 'http://localhost/media/user-image-1.webp',
+                isPublic: false,
+                createdAt: '2026-01-01T00:00:00.000Z',
+            },
+        ],
+    });
+});
+
+test('mounted app responds to DELETE /images/:imageId', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, { path: '/images/image-1', method: 'DELETE' });
+
+    assert.notEqual(response.statusCode, 404);
+});
+
+test('DELETE /images/:imageId returns status 200', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, { path: '/images/image-1', method: 'DELETE' });
+
+    assert.equal(response.statusCode, 200);
+});
+
+test('DELETE /images/:imageId returns delete result', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, { path: '/images/image-1', method: 'DELETE' });
+
+    assert.deepEqual(response.json, {
+        imageId: 'image-1',
+        deleted: true,
+    });
+});
+
+test('mounted app responds to PATCH /images/:imageId/visibility', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, {
+        path: '/images/image-1/visibility',
+        method: 'PATCH',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ isPublic: false }),
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json, {
+        image: {
+            id: 'image-1',
+            imageUrl: 'http://localhost/media/image-1.webp',
+            isPublic: false,
+            isArchived: false,
+            createdAt: '2026-01-01T00:00:00.000Z',
+        },
+    });
+});
+
+test('mounted app responds to POST /images/:imageId/archive', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, {
+        path: '/images/image-1/archive',
+        method: 'POST',
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json.image.isArchived, true);
+});
+
+test('mounted app responds to POST /images/:imageId/unarchive', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, {
+        path: '/images/image-1/unarchive',
+        method: 'POST',
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json.image.isArchived, false);
+});
+
+test('OPTIONS /images/:imageId DELETE preflight returns successful status', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, {
+        path: '/images/test-image-id',
+        method: 'OPTIONS',
+        headers: {
+            Origin: 'http://localhost:3000',
+            'Access-Control-Request-Method': 'DELETE',
+            'Access-Control-Request-Headers': 'authorization',
+        },
+    });
+
+    assert.equal(response.statusCode, 204);
+});
+
+test('OPTIONS /images/:imageId DELETE preflight allows localhost frontend origin', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, {
+        path: '/images/test-image-id',
+        method: 'OPTIONS',
+        headers: {
+            Origin: 'http://localhost:3000',
+            'Access-Control-Request-Method': 'DELETE',
+            'Access-Control-Request-Headers': 'authorization',
+        },
+    });
+
+    assert.equal(response.headers['access-control-allow-origin'], 'http://localhost:3000');
+});
+
+test('OPTIONS /images/:imageId DELETE preflight allows DELETE method', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, {
+        path: '/images/test-image-id',
+        method: 'OPTIONS',
+        headers: {
+            Origin: 'http://localhost:3000',
+            'Access-Control-Request-Method': 'DELETE',
+            'Access-Control-Request-Headers': 'authorization',
+        },
+    });
+
+    assert.equal(parseHeaderList(response.headers['access-control-allow-methods']).includes('delete'), true);
+});
+
+test('OPTIONS /images/:imageId DELETE preflight allows Authorization header', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, {
+        path: '/images/test-image-id',
+        method: 'OPTIONS',
+        headers: {
+            Origin: 'http://localhost:3000',
+            'Access-Control-Request-Method': 'DELETE',
+            'Access-Control-Request-Headers': 'authorization',
+        },
+    });
+
+    assert.equal(parseHeaderList(response.headers['access-control-allow-headers']).includes('authorization'), true);
+});
+
+test('OPTIONS /images/:imageId DELETE preflight does not call authProvider.requireUser', async () => {
+    const container = createFakeContainer();
+    const app = getCreateApp()({ container });
+
+    await request(app, {
+        path: '/images/test-image-id',
+        method: 'OPTIONS',
+        headers: {
+            Origin: 'http://localhost:3000',
+            'Access-Control-Request-Method': 'DELETE',
+            'Access-Control-Request-Headers': 'authorization',
+        },
+    });
+
+    assert.equal(container.calls.some((call) => call.method === 'requireUser'), false);
+});
+
+test('OPTIONS /images/:imageId/visibility PATCH preflight allows PATCH method', async () => {
+    const container = createFakeContainer();
+    const app = getCreateApp()({ container });
+
+    const response = await request(app, {
+        path: '/images/test-image-id/visibility',
+        method: 'OPTIONS',
+        headers: {
+            Origin: 'http://localhost:3000',
+            'Access-Control-Request-Method': 'PATCH',
+            'Access-Control-Request-Headers': 'authorization,content-type',
+        },
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(parseHeaderList(response.headers['access-control-allow-methods']).includes('patch'), true);
+    assert.equal(parseHeaderList(response.headers['access-control-allow-headers']).includes('authorization'), true);
+    assert.equal(container.calls.some((call) => call.method === 'requireUser'), false);
+});
+
+test('DELETE /images/:imageId still calls authProvider.requireUser', async () => {
+    const container = createFakeContainer();
+    const app = getCreateApp()({ container });
+
+    await request(app, { path: '/images/image-1', method: 'DELETE' });
+
+    assert.equal(container.calls.some((call) => call.method === 'requireUser'), true);
+});
+
+test('canonical routes use injected fake dependencies', async () => {
+    const container = createFakeContainer();
+    const app = getCreateApp()({ container });
+
+    await request(app, { path: '/images/public?limit=1' });
+    await request(app, { path: '/images/me' });
+    await request(app, { path: '/images/image-1', method: 'DELETE' });
+
+    assert.deepEqual(container.calls.map((call) => call.method), [
+        'listPublicImages',
+        'requireUser',
+        'listUserImages',
+        'requireUser',
+        'deleteImage',
+    ]);
+});
+
+test('mounted app responds to POST /images using fake dependencies', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, { path: '/images', method: 'POST' });
+
+    assert.equal(response.statusCode, 201);
+    assert.deepEqual(response.json, {
+        image: {
+            id: 'uploaded-image-1',
+            imageUrl: 'http://localhost/media/uploaded-image-1.webp',
+            isPublic: true,
+            createdAt: '2026-01-01T00:00:00.000Z',
+        },
+    });
+});
+
+test('POST /images uses injected auth and upload service dependencies', async () => {
+    const container = createFakeContainer();
+    const app = getCreateApp()({ container });
+
+    await request(app, { path: '/images', method: 'POST' });
+
+    assert.deepEqual(container.calls.map((call) => call.method), [
+        'requireUser',
+        'uploadImage',
+    ]);
+});
+
+test('createApp() without a container still creates an app without throwing', () => {
+    const createApp = getCreateApp();
+
+    assert.doesNotThrow(() => createApp());
+});
+
+test('createApp({ container }) mounts /media when container.config.storageProvider is local', async () => {
+    const app = getCreateApp()({
+        container: createFakeContainer({
+            storageProviderName: 'local',
+        }),
+    });
+
+    const response = await request(app, {
+        path: '/media/users/user-1/images/image-1.webp',
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.body, 'content:users/user-1/images/image-1.webp');
+});
+
+test('GET /media/... uses injected container.storageProvider', async () => {
+    const container = createFakeContainer({
+        storageProviderName: 'local',
+    });
+    const app = getCreateApp()({ container });
+
+    await request(app, {
+        path: '/media/users/user-1/images/image-1.webp',
+    });
+
+    assert.deepEqual(container.calls.filter((call) => call.method === 'objectExists' || call.method === 'createReadStream'), [
+        {
+            method: 'objectExists',
+            storageKey: 'users/user-1/images/image-1.webp',
+        },
+        {
+            method: 'createReadStream',
+            storageKey: 'users/user-1/images/image-1.webp',
+        },
+    ]);
+});
+
+test('createApp({ container }) does not mount /media when storage provider is not local', async () => {
+    const app = getCreateApp()({
+        container: createFakeContainer({
+            storageProviderName: 'firebase',
+        }),
+    });
+
+    const response = await request(app, {
+        path: '/media/users/user-1/images/image-1.webp',
+    });
+
+    assert.equal(response.statusCode, 404);
+});
+
+test('existing health route still works', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, { path: '/health' });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.body, 'OK');
+});
+
+test('legacy route modules are not removed', () => {
+    assert.equal(typeof createImageRouter, 'function');
+});
+
+test('/resize-upload is not replaced by the new image API router', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, { path: '/resize-upload', method: 'POST' });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(response.json, { error: 'No image file provided.' });
+});
+
+test('/delete-image is not replaced by the new image API router', async () => {
+    const app = getCreateApp()({ container: createFakeContainer() });
+
+    const response = await request(app, { path: '/delete-image', method: 'POST' });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.body, 'Image name is required');
+});
+
+test('error handler still receives errors from canonical image routes', async () => {
+    const app = getCreateApp()({
+        container: createFakeContainer({
+            listPublicImagesError: new Error('canonical route failed'),
+        }),
+    });
+
+    const response = await request(app, { path: '/images/public' });
+
+    assert.equal(response.statusCode, 500);
+    assert.deepEqual(response.json, { error: 'Internal server error' });
+});

--- a/tests/container.test.js
+++ b/tests/container.test.js
@@ -1,0 +1,322 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createContainer } = require('../config/container');
+
+const createConfig = (overrides = {}) => ({
+    authProvider: 'firebase',
+    databaseProvider: 'sqlite',
+    storageProvider: 'local',
+    ...overrides,
+});
+
+const createFakeAuthProvider = (type = 'firebaseAuth') => ({
+    type,
+    getCurrentUser: async () => null,
+    requireUser: async () => ({ uid: 'user-1' }),
+});
+
+const createFakeImageRepository = (type = 'sqliteRepository', overrides = {}) => ({
+    type,
+    listPublicImages: async () => [],
+    listImagesByOwner: async () => [],
+    findImageById: async () => null,
+    createImage: async (image) => image,
+    updateImageVisibility: async (imageId, ownerId, isPublic) => ({ id: imageId, ownerId, isPublic }),
+    archiveImageById: async (imageId, ownerId) => ({ id: imageId, ownerId, archivedAt: '2026-01-01T00:00:00.000Z' }),
+    unarchiveImageById: async (imageId, ownerId) => ({ id: imageId, ownerId, archivedAt: null }),
+    deleteImageById: async (imageId) => ({ imageId, deleted: true }),
+    ...overrides,
+});
+
+const createFakeStorageProvider = (type = 'localStorage', overrides = {}) => ({
+    type,
+    getUrl: (storageKey) => `http://localhost/media/${storageKey}`,
+    saveObject: async ({ storageKey }) => ({ storageKey, sizeBytes: 10 }),
+    deleteObject: async (storageKey) => ({ storageKey, deleted: true }),
+    ...overrides,
+});
+
+const createCountingFactory = (providerFactory, calls) => (context) => {
+    calls.push(context);
+    return providerFactory();
+};
+
+const createProviderRegistry = (calls = { auth: [], repository: [], storage: [] }) => ({
+    authProviders: {
+        firebase: createCountingFactory(() => createFakeAuthProvider('firebaseAuth'), calls.auth),
+        local: createCountingFactory(() => createFakeAuthProvider('localAuth'), calls.auth),
+    },
+    imageRepositories: {
+        firebase: createCountingFactory(() => createFakeImageRepository('firebaseRepository'), calls.repository),
+        sqlite: createCountingFactory(() => createFakeImageRepository('sqliteRepository'), calls.repository),
+    },
+    storageProviders: {
+        firebase: createCountingFactory(() => createFakeStorageProvider('firebaseStorage'), calls.storage),
+        local: createCountingFactory(() => createFakeStorageProvider('localStorage'), calls.storage),
+    },
+});
+
+const assertContainerError = (callback, messagePart) => {
+    assert.throws(
+        callback,
+        (error) => error instanceof Error && error.message.includes(messagePart),
+    );
+};
+
+test('creates a container with selected providers', () => {
+    const calls = { auth: [], repository: [], storage: [] };
+    const config = createConfig();
+    const registry = createProviderRegistry(calls);
+
+    const container = createContainer(config, registry);
+
+    assert.equal(container.config, config);
+    assert.equal(container.authProvider.type, 'firebaseAuth');
+    assert.equal(container.imageRepository.type, 'sqliteRepository');
+    assert.equal(container.storageProvider.type, 'localStorage');
+    assert.equal(typeof container.imagePresenter.toImageDto, 'function');
+    assert.equal(typeof container.imageService.listPublicImages, 'function');
+    assert.equal(typeof container.imageUploadService.uploadImage, 'function');
+});
+
+test('returns config', () => {
+    const config = createConfig();
+    const container = createContainer(config, createProviderRegistry());
+
+    assert.equal(container.config, config);
+});
+
+test('returns authProvider', () => {
+    const container = createContainer(createConfig(), createProviderRegistry());
+
+    assert.equal(container.authProvider.type, 'firebaseAuth');
+});
+
+test('returns imageRepository', () => {
+    const container = createContainer(createConfig(), createProviderRegistry());
+
+    assert.equal(container.imageRepository.type, 'sqliteRepository');
+});
+
+test('returns storageProvider', () => {
+    const container = createContainer(createConfig(), createProviderRegistry());
+
+    assert.equal(container.storageProvider.type, 'localStorage');
+});
+
+test('returns imagePresenter', () => {
+    const container = createContainer(createConfig(), createProviderRegistry());
+
+    assert.equal(typeof container.imagePresenter.toImageDto, 'function');
+    assert.equal(typeof container.imagePresenter.toImageDtos, 'function');
+});
+
+test('returns imageService', () => {
+    const container = createContainer(createConfig(), createProviderRegistry());
+
+    assert.equal(typeof container.imageService.listPublicImages, 'function');
+    assert.equal(typeof container.imageService.listUserImages, 'function');
+    assert.equal(typeof container.imageService.findImageById, 'function');
+    assert.equal(typeof container.imageService.createImage, 'function');
+    assert.equal(typeof container.imageService.updateImageVisibility, 'function');
+    assert.equal(typeof container.imageService.archiveImage, 'function');
+    assert.equal(typeof container.imageService.unarchiveImage, 'function');
+    assert.equal(typeof container.imageService.deleteImage, 'function');
+});
+
+test('returns imageUploadService', () => {
+    const container = createContainer(createConfig(), createProviderRegistry());
+
+    assert.equal(typeof container.imageUploadService.uploadImage, 'function');
+});
+
+test('selected auth provider factory is called once', () => {
+    const calls = { auth: [], repository: [], storage: [] };
+    createContainer(createConfig(), createProviderRegistry(calls));
+
+    assert.equal(calls.auth.length, 1);
+});
+
+test('selected image repository factory is called once', () => {
+    const calls = { auth: [], repository: [], storage: [] };
+    createContainer(createConfig(), createProviderRegistry(calls));
+
+    assert.equal(calls.repository.length, 1);
+});
+
+test('selected storage provider factory is called once', () => {
+    const calls = { auth: [], repository: [], storage: [] };
+    createContainer(createConfig(), createProviderRegistry(calls));
+
+    assert.equal(calls.storage.length, 1);
+});
+
+test('passes the same normalized config object to every selected provider factory', () => {
+    const calls = { auth: [], repository: [], storage: [] };
+    const config = createConfig();
+    createContainer(config, createProviderRegistry(calls));
+
+    assert.equal(calls.auth[0].config, config);
+    assert.equal(calls.repository[0].config, config);
+    assert.equal(calls.storage[0].config, config);
+});
+
+test('supports the MVP provider combination', () => {
+    const container = createContainer(
+        createConfig({
+            authProvider: 'firebase',
+            databaseProvider: 'sqlite',
+            storageProvider: 'local',
+        }),
+        createProviderRegistry(),
+    );
+
+    assert.equal(container.authProvider.type, 'firebaseAuth');
+    assert.equal(container.imageRepository.type, 'sqliteRepository');
+    assert.equal(container.storageProvider.type, 'localStorage');
+    assert.equal(typeof container.imagePresenter.toImageDto, 'function');
+    assert.equal(typeof container.imageService.createImage, 'function');
+    assert.equal(typeof container.imageUploadService.uploadImage, 'function');
+});
+
+test('supports the all-Firebase provider combination when fake registry entries exist', () => {
+    const container = createContainer(
+        createConfig({
+            authProvider: 'firebase',
+            databaseProvider: 'firebase',
+            storageProvider: 'firebase',
+        }),
+        createProviderRegistry(),
+    );
+
+    assert.equal(container.authProvider.type, 'firebaseAuth');
+    assert.equal(container.imageRepository.type, 'firebaseRepository');
+    assert.equal(container.storageProvider.type, 'firebaseStorage');
+    assert.equal(typeof container.imageService.listPublicImages, 'function');
+});
+
+test('supports the all-local provider combination when fake registry entries exist', () => {
+    const container = createContainer(
+        createConfig({
+            authProvider: 'local',
+            databaseProvider: 'sqlite',
+            storageProvider: 'local',
+        }),
+        createProviderRegistry(),
+    );
+
+    assert.equal(container.authProvider.type, 'localAuth');
+    assert.equal(container.imageRepository.type, 'sqliteRepository');
+    assert.equal(container.storageProvider.type, 'localStorage');
+    assert.equal(typeof container.imageService.listUserImages, 'function');
+});
+
+test('rejects missing config', () => {
+    assertContainerError(() => createContainer(undefined, createProviderRegistry()), 'config');
+});
+
+test('rejects missing providerRegistry', () => {
+    assertContainerError(() => createContainer(createConfig()), 'providerRegistry');
+});
+
+test('rejects missing authProviders registry', () => {
+    assertContainerError(
+        () => createContainer(createConfig(), {
+            imageRepositories: {},
+            storageProviders: {},
+        }),
+        'providerRegistry.authProviders',
+    );
+});
+
+test('rejects missing imageRepositories registry', () => {
+    assertContainerError(
+        () => createContainer(createConfig(), {
+            authProviders: {},
+            storageProviders: {},
+        }),
+        'providerRegistry.imageRepositories',
+    );
+});
+
+test('rejects missing storageProviders registry', () => {
+    assertContainerError(
+        () => createContainer(createConfig(), {
+            authProviders: {},
+            imageRepositories: {},
+        }),
+        'providerRegistry.storageProviders',
+    );
+});
+
+test('rejects missing selected auth provider and includes AUTH_PROVIDER', () => {
+    const registry = createProviderRegistry();
+    delete registry.authProviders.firebase;
+
+    assertContainerError(() => createContainer(createConfig(), registry), 'AUTH_PROVIDER');
+});
+
+test('rejects missing selected image repository and includes DATABASE_PROVIDER', () => {
+    const registry = createProviderRegistry();
+    delete registry.imageRepositories.sqlite;
+
+    assertContainerError(() => createContainer(createConfig(), registry), 'DATABASE_PROVIDER');
+});
+
+test('rejects missing selected storage provider and includes STORAGE_PROVIDER', () => {
+    const registry = createProviderRegistry();
+    delete registry.storageProviders.local;
+
+    assertContainerError(() => createContainer(createConfig(), registry), 'STORAGE_PROVIDER');
+});
+
+test('rejects provider registry values that are not functions', () => {
+    const registry = createProviderRegistry();
+    registry.authProviders.firebase = {};
+
+    assertContainerError(() => createContainer(createConfig(), registry), 'must be a function');
+});
+
+test('rejects provider factories that return non-object values', () => {
+    const registry = createProviderRegistry();
+    registry.authProviders.firebase = () => null;
+
+    assertContainerError(() => createContainer(createConfig(), registry), 'must return an object');
+});
+
+test('rejects a storage provider missing getUrl', () => {
+    const registry = createProviderRegistry();
+    registry.storageProviders.local = () => createFakeStorageProvider('localStorage', { getUrl: undefined });
+
+    assertContainerError(() => createContainer(createConfig(), registry), 'storageProvider.getUrl');
+});
+
+test('rejects dependencies that cannot create imageService', () => {
+    const registry = createProviderRegistry();
+    registry.storageProviders.local = () => createFakeStorageProvider('localStorage', { deleteObject: undefined });
+
+    assertContainerError(() => createContainer(createConfig(), registry), 'storageProvider.deleteObject');
+});
+
+test('does not mutate the config object', () => {
+    const config = createConfig();
+    const before = JSON.stringify(config);
+
+    createContainer(config, createProviderRegistry());
+
+    assert.equal(JSON.stringify(config), before);
+});
+
+test('does not mutate the provider registry', () => {
+    const registry = createProviderRegistry();
+    const beforeAuthKeys = Object.keys(registry.authProviders);
+    const beforeRepositoryKeys = Object.keys(registry.imageRepositories);
+    const beforeStorageKeys = Object.keys(registry.storageProviders);
+
+    createContainer(createConfig(), registry);
+
+    assert.deepEqual(Object.keys(registry.authProviders), beforeAuthKeys);
+    assert.deepEqual(Object.keys(registry.imageRepositories), beforeRepositoryKeys);
+    assert.deepEqual(Object.keys(registry.storageProviders), beforeStorageKeys);
+});

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -1,109 +1,169 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const ENV_MODULE_PATH = '../config/env';
-
-const loadEnvModule = () => {
-    delete require.cache[require.resolve(ENV_MODULE_PATH)];
-    return require(ENV_MODULE_PATH);
+const originalEnv = process.env;
+process.env = {
+    ...originalEnv,
+    FIREBASE_SERVICE_ACCOUNT_PATH: '/tmp/firebase-service-account.json',
 };
 
-test('env config uses defaults when env vars are not set', () => {
-    const original = { ...process.env };
-    delete process.env.MAX_FILE_SIZE_MB;
-    delete process.env.IMAGE_PROCESSOR;
-    delete process.env.LOW_MEMORY_MODE;
-    delete process.env.RESIZE_CONCURRENCY;
+const { readEnv } = require('../config/env');
 
-    const env = loadEnvModule();
+process.env = originalEnv;
 
-    assert.equal(env.MAX_FILE_SIZE, 5 * 1024 * 1024);
-    assert.equal(env.IMAGE_PROCESSOR, 'sharp');
+const baseEnv = {
+    NODE_ENV: 'development',
+    PORT: '3000',
+    AUTH_PROVIDER: 'firebase',
+    DATABASE_PROVIDER: 'sqlite',
+    STORAGE_PROVIDER: 'local',
+    SQLITE_PATH: './data/photogram.sqlite',
+    LOCAL_STORAGE_ROOT: './data/images',
+    PUBLIC_MEDIA_BASE_URL: 'http://localhost:3000/media',
+    FIREBASE_SERVICE_ACCOUNT_PATH: '/secure/photogram/firebase-service-account.json',
+    FIREBASE_URL_MODE: 'signed',
+    FIREBASE_SIGNED_URL_EXPIRES_SECONDS: '300',
+    LOW_MEMORY_MODE: 'true',
+    MAX_FILE_SIZE_MB: '5',
+    RESIZE_CONCURRENCY: '1',
+    HEAVY_RATE_LIMIT_MAX: '8',
+    ENABLE_DEBUG_ENDPOINT: 'false',
+    IMAGE_PROCESSOR: 'sharp',
+};
 
-    process.env = original;
+const withEnv = (overrides) => ({ ...baseEnv, ...overrides });
+
+const assertEnvError = (env, envName) => {
+    assert.throws(
+        () => readEnv(env),
+        (error) => error instanceof Error && error.message.includes(envName),
+    );
+};
+
+test('parses the local MVP provider configuration', () => {
+    const config = readEnv(baseEnv);
+
+    assert.equal(config.authProvider, 'firebase');
+    assert.equal(config.databaseProvider, 'sqlite');
+    assert.equal(config.storageProvider, 'local');
+    assert.equal(config.sqlitePath, './data/photogram.sqlite');
+    assert.equal(config.localStorageRoot, './data/images');
+    assert.equal(config.publicMediaBaseUrl, 'http://localhost:3000/media');
 });
 
-test('env config applies MAX_FILE_SIZE_MB override', () => {
-    const original = { ...process.env };
-    process.env.LOW_MEMORY_MODE = 'false';
-    process.env.MAX_FILE_SIZE_MB = '7';
-
-    const env = loadEnvModule();
-
-    assert.equal(env.MAX_FILE_SIZE, 7 * 1024 * 1024);
-
-    process.env = original;
+test('rejects invalid AUTH_PROVIDER', () => {
+    assertEnvError(withEnv({ AUTH_PROVIDER: 'oauth' }), 'AUTH_PROVIDER');
 });
 
-test('env config supports signed URL mode overrides', () => {
-    const original = { ...process.env };
-    process.env.FIREBASE_URL_MODE = 'signed';
-    process.env.FIREBASE_SIGNED_URL_EXPIRES_SECONDS = '120';
-
-    const env = loadEnvModule();
-
-    assert.equal(env.FIREBASE_URL_MODE, 'signed');
-    assert.equal(env.FIREBASE_SIGNED_URL_EXPIRES_SECONDS, 120);
-
-    process.env = original;
+test('rejects invalid DATABASE_PROVIDER', () => {
+    assertEnvError(withEnv({ DATABASE_PROVIDER: 'postgres' }), 'DATABASE_PROVIDER');
 });
 
-test('env config clamps limits in low-memory mode', () => {
-    const original = { ...process.env };
-    process.env.LOW_MEMORY_MODE = 'true';
-    process.env.MAX_FILE_SIZE_MB = '80';
-    process.env.RESIZE_CONCURRENCY = '8';
-
-    const env = loadEnvModule();
-
-    assert.equal(env.LOW_MEMORY_MODE, true);
-    assert.equal(env.MAX_FILE_SIZE_MB, 10);
-    assert.equal(env.MAX_FILE_SIZE, 10 * 1024 * 1024);
-    assert.equal(env.MAX_FILE_SIZE_WAS_CLAMPED, true);
-    assert.equal(env.RESIZE_CONCURRENCY, 1);
-    assert.equal(env.RESIZE_CONCURRENCY_WAS_CLAMPED, true);
-
-    process.env = original;
+test('rejects invalid STORAGE_PROVIDER', () => {
+    assertEnvError(withEnv({ STORAGE_PROVIDER: 's3' }), 'STORAGE_PROVIDER');
 });
 
-test('env config allows higher caps when low-memory mode is disabled', () => {
-    const original = { ...process.env };
-    process.env.LOW_MEMORY_MODE = 'false';
-    process.env.MAX_FILE_SIZE_MB = '20';
-    process.env.RESIZE_CONCURRENCY = '3';
-
-    const env = loadEnvModule();
-
-    assert.equal(env.LOW_MEMORY_MODE, false);
-    assert.equal(env.MAX_FILE_SIZE_MB, 20);
-    assert.equal(env.MAX_FILE_SIZE_WAS_CLAMPED, false);
-    assert.equal(env.RESIZE_CONCURRENCY, 3);
-    assert.equal(env.RESIZE_CONCURRENCY_WAS_CLAMPED, false);
-
-    process.env = original;
+test('rejects invalid IMAGE_PROCESSOR', () => {
+    assertEnvError(withEnv({ IMAGE_PROCESSOR: 'imagemagick' }), 'IMAGE_PROCESSOR');
 });
 
-test('env config clamps heavy rate limit in low-memory mode', () => {
-    const original = { ...process.env };
-    process.env.LOW_MEMORY_MODE = 'true';
-    process.env.HEAVY_RATE_LIMIT_MAX = '100';
-
-    const env = loadEnvModule();
-
-    assert.equal(env.HEAVY_RATE_LIMIT_MAX, 12);
-    assert.equal(env.HEAVY_RATE_LIMIT_WAS_CLAMPED, true);
-
-    process.env = original;
+test('rejects invalid FIREBASE_URL_MODE', () => {
+    assertEnvError(withEnv({ FIREBASE_URL_MODE: 'private' }), 'FIREBASE_URL_MODE');
 });
 
-test('env config disables debug endpoint by default in production', () => {
-    const original = { ...process.env };
-    process.env.NODE_ENV = 'production';
-    delete process.env.ENABLE_DEBUG_ENDPOINT;
+test('parses boolean values', () => {
+    const config = readEnv(withEnv({
+        LOW_MEMORY_MODE: 'false',
+        ENABLE_DEBUG_ENDPOINT: 'true',
+    }));
 
-    const env = loadEnvModule();
+    assert.equal(config.lowMemoryMode, false);
+    assert.equal(config.enableDebugEndpoint, true);
+});
 
-    assert.equal(env.ENABLE_DEBUG_ENDPOINT, false);
+test('rejects invalid boolean values', () => {
+    assertEnvError(withEnv({ LOW_MEMORY_MODE: 'yes' }), 'LOW_MEMORY_MODE');
+    assertEnvError(withEnv({ ENABLE_DEBUG_ENDPOINT: 'auto' }), 'ENABLE_DEBUG_ENDPOINT');
+});
 
-    process.env = original;
+test('parses numeric values', () => {
+    const config = readEnv(withEnv({
+        PORT: '3003',
+        FIREBASE_SIGNED_URL_EXPIRES_SECONDS: '120',
+        MAX_FILE_SIZE_MB: '7',
+        RESIZE_CONCURRENCY: '3',
+        HEAVY_RATE_LIMIT_MAX: '11',
+        LOW_MEMORY_MODE: 'false',
+    }));
+
+    assert.equal(config.port, 3003);
+    assert.equal(config.firebaseSignedUrlExpiresSeconds, 120);
+    assert.equal(config.maxFileSizeMb, 7);
+    assert.equal(config.resizeConcurrency, 3);
+    assert.equal(config.heavyRateLimitMax, 11);
+});
+
+test('rejects invalid numeric values', () => {
+    assertEnvError(withEnv({ PORT: '0' }), 'PORT');
+    assertEnvError(withEnv({ FIREBASE_SIGNED_URL_EXPIRES_SECONDS: '-1' }), 'FIREBASE_SIGNED_URL_EXPIRES_SECONDS');
+    assertEnvError(withEnv({ MAX_FILE_SIZE_MB: '1.5' }), 'MAX_FILE_SIZE_MB');
+    assertEnvError(withEnv({ RESIZE_CONCURRENCY: 'many' }), 'RESIZE_CONCURRENCY');
+    assertEnvError(withEnv({ HEAVY_RATE_LIMIT_MAX: '0' }), 'HEAVY_RATE_LIMIT_MAX');
+});
+
+test('sqlite mode includes sqlitePath', () => {
+    const config = readEnv(withEnv({
+        DATABASE_PROVIDER: 'sqlite',
+        SQLITE_PATH: './custom/photogram.sqlite',
+    }));
+
+    assert.equal(config.sqlitePath, './custom/photogram.sqlite');
+});
+
+test('local storage mode includes localStorageRoot', () => {
+    const config = readEnv(withEnv({
+        STORAGE_PROVIDER: 'local',
+        LOCAL_STORAGE_ROOT: './custom/images',
+    }));
+
+    assert.equal(config.localStorageRoot, './custom/images');
+});
+
+test('local storage mode includes publicMediaBaseUrl', () => {
+    const config = readEnv(withEnv({
+        STORAGE_PROVIDER: 'local',
+        PUBLIC_MEDIA_BASE_URL: 'http://localhost:3000/custom-media',
+    }));
+
+    assert.equal(config.publicMediaBaseUrl, 'http://localhost:3000/custom-media');
+});
+
+test('Firebase auth mode requires FIREBASE_SERVICE_ACCOUNT_PATH', () => {
+    const env = withEnv({ AUTH_PROVIDER: 'firebase' });
+    delete env.FIREBASE_SERVICE_ACCOUNT_PATH;
+
+    assertEnvError(env, 'FIREBASE_SERVICE_ACCOUNT_PATH');
+});
+
+test('Firebase storage mode requires FIREBASE_STORAGE_BUCKET', () => {
+    const env = withEnv({
+        STORAGE_PROVIDER: 'firebase',
+        FIREBASE_STORAGE_BUCKET: '',
+    });
+
+    assertEnvError(env, 'FIREBASE_STORAGE_BUCKET');
+});
+
+test('returned config uses camelCase property names', () => {
+    const config = readEnv(baseEnv);
+
+    assert.equal(Object.prototype.hasOwnProperty.call(config, 'nodeEnv'), true);
+    assert.equal(Object.prototype.hasOwnProperty.call(config, 'authProvider'), true);
+    assert.equal(Object.prototype.hasOwnProperty.call(config, 'firebaseServiceAccountPath'), true);
+    assert.equal(Object.prototype.hasOwnProperty.call(config, 'AUTH_PROVIDER'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(config, 'FIREBASE_SERVICE_ACCOUNT_PATH'), false);
+});
+
+test('error messages include the relevant env var name', () => {
+    assertEnvError(withEnv({ FIREBASE_URL_MODE: 'temporary' }), 'FIREBASE_URL_MODE');
 });

--- a/tests/firebaseAuthProvider.test.js
+++ b/tests/firebaseAuthProvider.test.js
@@ -1,0 +1,200 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createFirebaseAuthProvider } = require('../auth/firebaseAuthProvider');
+
+const createFakeFirebaseAuth = (decodedToken, options = {}) => {
+    const calls = [];
+    return {
+        calls,
+        async verifyIdToken(token) {
+            calls.push(token);
+            if (options.reject) {
+                throw new Error(options.reject);
+            }
+            return decodedToken;
+        },
+    };
+};
+
+const createRequest = (authorization) => ({
+    headers: authorization === undefined ? {} : { authorization },
+});
+
+const assertUnauthorized = async (callback) => {
+    await assert.rejects(
+        callback,
+        (error) => error instanceof Error
+            && error.statusCode === 401
+            && error.code === 'UNAUTHENTICATED',
+    );
+};
+
+test('creates a Firebase Auth provider', () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth({ uid: 'user-1' }),
+    });
+
+    assert.equal(typeof provider.getCurrentUser, 'function');
+    assert.equal(typeof provider.requireUser, 'function');
+});
+
+test('getCurrentUser returns null when Authorization header is missing', async () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth({ uid: 'user-1' }),
+    });
+
+    const user = await provider.getCurrentUser({ headers: {} });
+
+    assert.equal(user, null);
+});
+
+test('rejects non-Bearer Authorization header', async () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth({ uid: 'user-1' }),
+    });
+
+    await assertUnauthorized(() => provider.getCurrentUser(createRequest('Basic token')));
+});
+
+test('rejects empty Bearer token', async () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth({ uid: 'user-1' }),
+    });
+
+    await assertUnauthorized(() => provider.getCurrentUser(createRequest('Bearer ')));
+});
+
+test('calls verifyIdToken with the extracted token', async () => {
+    const firebaseAuth = createFakeFirebaseAuth({ uid: 'user-1' });
+    const provider = createFirebaseAuthProvider({ firebaseAuth });
+
+    await provider.getCurrentUser(createRequest('Bearer token-1'));
+
+    assert.deepEqual(firebaseAuth.calls, ['token-1']);
+});
+
+test('normalizes decoded token with uid', async () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth({ uid: 'user-1', email: 'user@example.com' }),
+    });
+
+    const user = await provider.getCurrentUser(createRequest('Bearer token-1'));
+
+    assert.equal(user.uid, 'user-1');
+    assert.equal(user.email, 'user@example.com');
+});
+
+test('normalizes decoded token with user_id fallback', async () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth({ user_id: 'user-2' }),
+    });
+
+    const user = await provider.getCurrentUser(createRequest('Bearer token-1'));
+
+    assert.equal(user.uid, 'user-2');
+});
+
+test('normalizes decoded token with sub fallback', async () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth({ sub: 'user-3' }),
+    });
+
+    const user = await provider.getCurrentUser(createRequest('Bearer token-1'));
+
+    assert.equal(user.uid, 'user-3');
+});
+
+test('defaults optional user fields to null or false', async () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth({ uid: 'user-1' }),
+    });
+
+    const user = await provider.getCurrentUser(createRequest('Bearer token-1'));
+
+    assert.equal(user.email, null);
+    assert.equal(user.emailVerified, false);
+    assert.equal(user.displayName, null);
+    assert.equal(user.photoUrl, null);
+});
+
+test('includes original decoded token as claims', async () => {
+    const decodedToken = { uid: 'user-1', custom: 'claim' };
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth(decodedToken),
+    });
+
+    const user = await provider.getCurrentUser(createRequest('Bearer token-1'));
+
+    assert.equal(user.claims, decodedToken);
+});
+
+test('rejects verified token with no usable UID', async () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth({ email: 'user@example.com' }),
+    });
+
+    await assertUnauthorized(() => provider.getCurrentUser(createRequest('Bearer token-1')));
+});
+
+test('converts Firebase verification failure into unauthorized error', async () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth(null, { reject: 'expired token' }),
+    });
+
+    await assertUnauthorized(() => provider.getCurrentUser(createRequest('Bearer token-1')));
+});
+
+test('requireUser returns user when token is valid', async () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth({ uid: 'user-1' }),
+    });
+
+    const user = await provider.requireUser(createRequest('Bearer token-1'));
+
+    assert.equal(user.uid, 'user-1');
+});
+
+test('requireUser throws unauthorized when no user is present', async () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth({ uid: 'user-1' }),
+    });
+
+    await assertUnauthorized(() => provider.requireUser({ headers: {} }));
+});
+
+test('unauthorized errors include statusCode = 401', async () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth({ uid: 'user-1' }),
+    });
+
+    await assert.rejects(
+        () => provider.requireUser({ headers: {} }),
+        (error) => error.statusCode === 401,
+    );
+});
+
+test('unauthorized errors include code = UNAUTHENTICATED', async () => {
+    const provider = createFirebaseAuthProvider({
+        firebaseAuth: createFakeFirebaseAuth({ uid: 'user-1' }),
+    });
+
+    await assert.rejects(
+        () => provider.requireUser({ headers: {} }),
+        (error) => error.code === 'UNAUTHENTICATED',
+    );
+});
+
+test('provider does not require real Firebase when fake firebaseAuth is passed', async () => {
+    const firebaseAuth = createFakeFirebaseAuth({ uid: 'user-1' });
+    const provider = createFirebaseAuthProvider({ firebaseAuth });
+
+    const user = await provider.getCurrentUser({
+        headers: {
+            Authorization: 'Bearer token-1',
+        },
+    });
+
+    assert.equal(user.uid, 'user-1');
+    assert.deepEqual(firebaseAuth.calls, ['token-1']);
+});

--- a/tests/firebaseConfig.test.js
+++ b/tests/firebaseConfig.test.js
@@ -1,0 +1,192 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const firebaseConfigPath = require.resolve('../config/firebase');
+const envConfigPath = require.resolve('../config/env');
+const firebaseAdminPath = require.resolve('firebase-admin');
+
+const baseEnv = {
+    NODE_ENV: 'test',
+    PORT: '3000',
+    AUTH_PROVIDER: 'firebase',
+    DATABASE_PROVIDER: 'sqlite',
+    STORAGE_PROVIDER: 'local',
+    SQLITE_PATH: './data/photogram.sqlite',
+    LOCAL_STORAGE_ROOT: './data/images',
+    PUBLIC_MEDIA_BASE_URL: 'http://localhost:3000/media',
+    FIREBASE_URL_MODE: 'signed',
+    FIREBASE_SIGNED_URL_EXPIRES_SECONDS: '300',
+    LOW_MEMORY_MODE: 'true',
+    MAX_FILE_SIZE_MB: '5',
+    RESIZE_CONCURRENCY: '1',
+    HEAVY_RATE_LIMIT_MAX: '8',
+    ENABLE_DEBUG_ENDPOINT: 'false',
+    IMAGE_PROCESSOR: 'sharp',
+};
+
+const clearFirebaseConfigCache = () => {
+    delete require.cache[firebaseConfigPath];
+    delete require.cache[envConfigPath];
+};
+
+const createFakeAdmin = () => {
+    const calls = [];
+    const fakeAuth = {
+        verifyIdToken: async () => ({ uid: 'user-1' }),
+    };
+    const fakeAdmin = {
+        apps: [],
+        credential: {
+            cert(serviceAccount) {
+                calls.push({ method: 'cert', serviceAccount });
+                return { serviceAccount };
+            },
+        },
+        initializeApp(options) {
+            calls.push({ method: 'initializeApp', options });
+            fakeAdmin.apps.push({ options });
+            return fakeAdmin.apps[0];
+        },
+        storage() {
+            calls.push({ method: 'storage' });
+            return {
+                bucket(bucketName) {
+                    calls.push({ method: 'bucket', bucketName });
+                    return {
+                        name: bucketName,
+                        file: () => ({}),
+                    };
+                },
+            };
+        },
+        auth() {
+            calls.push({ method: 'auth' });
+            return fakeAuth;
+        },
+    };
+
+    return {
+        calls,
+        fakeAdmin,
+        fakeAuth,
+    };
+};
+
+const loadFirebaseConfig = async ({ firebaseStorageBucket } = {}) => {
+    const originalEnv = process.env;
+    const originalAdminCache = require.cache[firebaseAdminPath];
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'photogram-firebase-config-'));
+    const serviceAccountPath = path.join(tempDir, 'service-account.json');
+    await fs.writeFile(serviceAccountPath, JSON.stringify({
+        project_id: 'test-project',
+        client_email: 'firebase-admin@example.test',
+        private_key: 'fake-private-key',
+    }));
+
+    const { calls, fakeAdmin, fakeAuth } = createFakeAdmin();
+    require.cache[firebaseAdminPath] = {
+        id: firebaseAdminPath,
+        filename: firebaseAdminPath,
+        loaded: true,
+        exports: fakeAdmin,
+    };
+
+    process.env = {
+        ...originalEnv,
+        ...baseEnv,
+        FIREBASE_SERVICE_ACCOUNT_PATH: serviceAccountPath,
+    };
+
+    if (firebaseStorageBucket) {
+        process.env.FIREBASE_STORAGE_BUCKET = firebaseStorageBucket;
+    } else {
+        delete process.env.FIREBASE_STORAGE_BUCKET;
+    }
+
+    clearFirebaseConfigCache();
+    const firebaseConfig = require('../config/firebase');
+
+    const cleanup = async () => {
+        clearFirebaseConfigCache();
+        if (originalAdminCache) {
+            require.cache[firebaseAdminPath] = originalAdminCache;
+        } else {
+            delete require.cache[firebaseAdminPath];
+        }
+        process.env = originalEnv;
+        await fs.rm(tempDir, { recursive: true, force: true });
+    };
+
+    return {
+        calls,
+        fakeAdmin,
+        fakeAuth,
+        firebaseConfig,
+        cleanup,
+    };
+};
+
+test('config/firebase.js can be imported without FIREBASE_STORAGE_BUCKET when storage provider is local', async () => {
+    const context = await loadFirebaseConfig();
+    try {
+        assert.equal(typeof context.firebaseConfig.getAuth, 'function');
+        assert.equal(typeof context.firebaseConfig.getBucket, 'function');
+        assert.equal(context.calls.some((call) => call.method === 'bucket'), false);
+
+        const initializeCall = context.calls.find((call) => call.method === 'initializeApp');
+        assert.ok(initializeCall);
+        assert.equal(Object.hasOwn(initializeCall.options, 'storageBucket'), false);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('getBucket throws a clear FIREBASE_STORAGE_BUCKET error when no bucket is configured', async () => {
+    const context = await loadFirebaseConfig();
+    try {
+        assert.throws(
+            () => context.firebaseConfig.getBucket(),
+            /FIREBASE_STORAGE_BUCKET/,
+        );
+        assert.equal(context.calls.some((call) => call.method === 'bucket'), false);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('getBucket uses the configured FIREBASE_STORAGE_BUCKET', async () => {
+    const context = await loadFirebaseConfig({
+        firebaseStorageBucket: 'photogram-test.appspot.com',
+    });
+    try {
+        assert.equal(context.calls.some((call) => call.method === 'bucket'), false);
+
+        const initializeCall = context.calls.find((call) => call.method === 'initializeApp');
+        assert.equal(initializeCall.options.storageBucket, 'photogram-test.appspot.com');
+
+        const bucket = context.firebaseConfig.getBucket();
+        assert.equal(bucket.name, 'photogram-test.appspot.com');
+        assert.deepEqual(
+            context.calls.filter((call) => call.method === 'bucket').map((call) => call.bucketName),
+            ['photogram-test.appspot.com'],
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('Firebase Auth lazy getter still works without initializing Firebase Storage bucket', async () => {
+    const context = await loadFirebaseConfig();
+    try {
+        const auth = context.firebaseConfig.getAuth();
+
+        assert.equal(auth, context.fakeAuth);
+        assert.equal(context.calls.some((call) => call.method === 'auth'), true);
+        assert.equal(context.calls.some((call) => call.method === 'bucket'), false);
+    } finally {
+        await context.cleanup();
+    }
+});

--- a/tests/imageApiController.test.js
+++ b/tests/imageApiController.test.js
@@ -1,0 +1,762 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createImageApiController } = require('../controllers/imageApiController');
+
+const createResponse = () => ({
+    statusCode: null,
+    body: null,
+    status(code) {
+        this.statusCode = code;
+        return this;
+    },
+    json(payload) {
+        this.body = payload;
+        return this;
+    },
+});
+
+const createNext = () => {
+    const calls = [];
+    const next = (error) => calls.push(error);
+    next.calls = calls;
+    return next;
+};
+
+const createDependencies = (overrides = {}) => {
+    const serviceCalls = [];
+    const authCalls = [];
+    const currentUser = overrides.currentUser || { uid: 'user-1', email: 'user@example.com' };
+    const images = overrides.images || [{ id: 'image-1', imageUrl: 'http://localhost/media/image-1.webp' }];
+    const uploadedImage = overrides.uploadedImage || { id: 'image-2', imageUrl: 'http://localhost/media/image-2.webp' };
+    const deleteResult = overrides.deleteResult || { imageId: 'image-1', deleted: true };
+    const updatedImage = overrides.updatedImage === undefined
+        ? { id: 'image-1', imageUrl: 'http://localhost/media/image-1.webp' }
+        : overrides.updatedImage;
+
+    const imageService = {
+        calls: serviceCalls,
+        async listPublicImages(options) {
+            serviceCalls.push({ method: 'listPublicImages', options });
+            if (overrides.listPublicImagesError) {
+                throw overrides.listPublicImagesError;
+            }
+            return images;
+        },
+        async listUserImages(user, options) {
+            serviceCalls.push({ method: 'listUserImages', user, options });
+            if (overrides.listUserImagesError) {
+                throw overrides.listUserImagesError;
+            }
+            return images;
+        },
+        async updateImageVisibility(imageId, user, isPublic) {
+            serviceCalls.push({ method: 'updateImageVisibility', imageId, user, isPublic });
+            if (overrides.updateImageVisibilityError) {
+                throw overrides.updateImageVisibilityError;
+            }
+            return updatedImage;
+        },
+        async archiveImage(imageId, user) {
+            serviceCalls.push({ method: 'archiveImage', imageId, user });
+            if (overrides.archiveImageError) {
+                throw overrides.archiveImageError;
+            }
+            return updatedImage;
+        },
+        async unarchiveImage(imageId, user) {
+            serviceCalls.push({ method: 'unarchiveImage', imageId, user });
+            if (overrides.unarchiveImageError) {
+                throw overrides.unarchiveImageError;
+            }
+            return updatedImage;
+        },
+        async deleteImage(imageId, user) {
+            serviceCalls.push({ method: 'deleteImage', imageId, user });
+            if (overrides.deleteImageError) {
+                throw overrides.deleteImageError;
+            }
+            return deleteResult;
+        },
+    };
+
+    const uploadCalls = [];
+    const imageUploadService = {
+        calls: uploadCalls,
+        async uploadImage(input) {
+            uploadCalls.push(input);
+            if (overrides.uploadImageError) {
+                throw overrides.uploadImageError;
+            }
+            return uploadedImage;
+        },
+    };
+
+    const authProvider = {
+        calls: authCalls,
+        async requireUser(req) {
+            authCalls.push(req);
+            if (overrides.requireUserError) {
+                throw overrides.requireUserError;
+            }
+            return currentUser;
+        },
+    };
+
+    return {
+        imageService,
+        imageUploadService,
+        authProvider,
+        currentUser,
+        uploadedImage,
+    };
+};
+
+const createControllerContext = (overrides = {}) => {
+    const dependencies = createDependencies(overrides);
+    return {
+        ...dependencies,
+        controller: createImageApiController(dependencies),
+    };
+};
+
+const assertValidationError = (error, inputName) => {
+    assert.equal(error.statusCode, 400);
+    assert.equal(error.code, 'VALIDATION_ERROR');
+    assert.match(error.message, new RegExp(inputName));
+};
+
+test('creates an image API controller', () => {
+    const { controller } = createControllerContext();
+
+    assert.equal(typeof controller.listPublicImages, 'function');
+    assert.equal(typeof controller.listMyImages, 'function');
+    assert.equal(typeof controller.updateImageVisibility, 'function');
+    assert.equal(typeof controller.archiveImage, 'function');
+    assert.equal(typeof controller.unarchiveImage, 'function');
+    assert.equal(typeof controller.deleteImage, 'function');
+    assert.equal(typeof controller.uploadImage, 'function');
+});
+
+test('rejects missing imageService', () => {
+    const { authProvider } = createDependencies();
+
+    assert.throws(
+        () => createImageApiController({ authProvider }),
+        /imageService/,
+    );
+});
+
+test('rejects missing authProvider', () => {
+    const { imageService, imageUploadService } = createDependencies();
+
+    assert.throws(
+        () => createImageApiController({ imageService, imageUploadService }),
+        /authProvider/,
+    );
+});
+
+test('rejects missing imageUploadService', () => {
+    const { imageService, authProvider } = createDependencies();
+
+    assert.throws(
+        () => createImageApiController({ imageService, authProvider }),
+        /imageUploadService/,
+    );
+});
+
+test('rejects missing imageService.listPublicImages', () => {
+    const { imageService, imageUploadService, authProvider } = createDependencies();
+    imageService.listPublicImages = undefined;
+
+    assert.throws(
+        () => createImageApiController({ imageService, imageUploadService, authProvider }),
+        /imageService\.listPublicImages/,
+    );
+});
+
+test('rejects missing imageService.listUserImages', () => {
+    const { imageService, imageUploadService, authProvider } = createDependencies();
+    imageService.listUserImages = undefined;
+
+    assert.throws(
+        () => createImageApiController({ imageService, imageUploadService, authProvider }),
+        /imageService\.listUserImages/,
+    );
+});
+
+test('rejects missing imageService.deleteImage', () => {
+    const { imageService, imageUploadService, authProvider } = createDependencies();
+    imageService.deleteImage = undefined;
+
+    assert.throws(
+        () => createImageApiController({ imageService, imageUploadService, authProvider }),
+        /imageService\.deleteImage/,
+    );
+});
+
+test('rejects missing imageService.updateImageVisibility', () => {
+    const { imageService, imageUploadService, authProvider } = createDependencies();
+    imageService.updateImageVisibility = undefined;
+
+    assert.throws(
+        () => createImageApiController({ imageService, imageUploadService, authProvider }),
+        /imageService\.updateImageVisibility/,
+    );
+});
+
+test('rejects missing imageService.archiveImage', () => {
+    const { imageService, imageUploadService, authProvider } = createDependencies();
+    imageService.archiveImage = undefined;
+
+    assert.throws(
+        () => createImageApiController({ imageService, imageUploadService, authProvider }),
+        /imageService\.archiveImage/,
+    );
+});
+
+test('rejects missing imageService.unarchiveImage', () => {
+    const { imageService, imageUploadService, authProvider } = createDependencies();
+    imageService.unarchiveImage = undefined;
+
+    assert.throws(
+        () => createImageApiController({ imageService, imageUploadService, authProvider }),
+        /imageService\.unarchiveImage/,
+    );
+});
+
+test('rejects missing authProvider.requireUser', () => {
+    const { imageService, imageUploadService, authProvider } = createDependencies();
+    authProvider.requireUser = undefined;
+
+    assert.throws(
+        () => createImageApiController({ imageService, imageUploadService, authProvider }),
+        /authProvider\.requireUser/,
+    );
+});
+
+test('controller requires imageUploadService.uploadImage', () => {
+    const { imageService, imageUploadService, authProvider } = createDependencies();
+    imageUploadService.uploadImage = undefined;
+
+    assert.throws(
+        () => createImageApiController({ imageService, imageUploadService, authProvider }),
+        /imageUploadService\.uploadImage/,
+    );
+});
+
+test('listPublicImages calls imageService.listPublicImages', async () => {
+    const { controller, imageService } = createControllerContext();
+
+    await controller.listPublicImages({ query: {} }, createResponse(), createNext());
+
+    assert.equal(imageService.calls[0].method, 'listPublicImages');
+});
+
+test('listPublicImages responds with status 200', async () => {
+    const { controller } = createControllerContext();
+    const res = createResponse();
+
+    await controller.listPublicImages({ query: {} }, res, createNext());
+
+    assert.equal(res.statusCode, 200);
+});
+
+test('listPublicImages responds with { images }', async () => {
+    const images = [{ id: 'image-1' }];
+    const { controller } = createControllerContext({ images });
+    const res = createResponse();
+
+    await controller.listPublicImages({ query: {} }, res, createNext());
+
+    assert.deepEqual(res.body, { images });
+});
+
+test('listPublicImages passes parsed limit', async () => {
+    const { controller, imageService } = createControllerContext();
+
+    await controller.listPublicImages({ query: { limit: '50' } }, createResponse(), createNext());
+
+    assert.equal(imageService.calls[0].options.limit, 50);
+});
+
+test('listPublicImages passes parsed offset', async () => {
+    const { controller, imageService } = createControllerContext();
+
+    await controller.listPublicImages({ query: { offset: '0' } }, createResponse(), createNext());
+
+    assert.equal(imageService.calls[0].options.offset, 0);
+});
+
+test('listPublicImages omits pagination options when query is empty', async () => {
+    const { controller, imageService } = createControllerContext();
+
+    await controller.listPublicImages({ query: {} }, createResponse(), createNext());
+
+    assert.deepEqual(imageService.calls[0].options, {});
+});
+
+test('listPublicImages calls next(error) when service throws', async () => {
+    const serviceError = new Error('service failed');
+    const { controller } = createControllerContext({ listPublicImagesError: serviceError });
+    const next = createNext();
+
+    await controller.listPublicImages({ query: {} }, createResponse(), next);
+
+    assert.equal(next.calls[0], serviceError);
+});
+
+test('listMyImages calls authProvider.requireUser(req)', async () => {
+    const { controller, authProvider } = createControllerContext();
+    const req = { query: {} };
+
+    await controller.listMyImages(req, createResponse(), createNext());
+
+    assert.equal(authProvider.calls[0], req);
+});
+
+test('listMyImages calls imageService.listUserImages(currentUser, options)', async () => {
+    const { controller, imageService, currentUser } = createControllerContext();
+
+    await controller.listMyImages({ query: { limit: '10' } }, createResponse(), createNext());
+
+    assert.equal(imageService.calls[0].method, 'listUserImages');
+    assert.equal(imageService.calls[0].user, currentUser);
+    assert.deepEqual(imageService.calls[0].options, { limit: 10 });
+});
+
+test('listMyImages parses archived query option', async () => {
+    const { controller, imageService } = createControllerContext();
+
+    await controller.listMyImages({ query: { archived: 'true' } }, createResponse(), createNext());
+
+    assert.deepEqual(imageService.calls[0].options, { archived: true });
+});
+
+test('listMyImages parses includeArchived query option', async () => {
+    const { controller, imageService } = createControllerContext();
+
+    await controller.listMyImages({ query: { includeArchived: 'true' } }, createResponse(), createNext());
+
+    assert.deepEqual(imageService.calls[0].options, { includeArchived: true });
+});
+
+test('listMyImages rejects invalid archived query option', async () => {
+    const { controller } = createControllerContext();
+    const next = createNext();
+
+    await controller.listMyImages({ query: { archived: 'yes' } }, createResponse(), next);
+
+    assertValidationError(next.calls[0], 'archived');
+});
+
+test('listMyImages rejects invalid includeArchived query option', async () => {
+    const { controller } = createControllerContext();
+    const next = createNext();
+
+    await controller.listMyImages({ query: { includeArchived: [] } }, createResponse(), next);
+
+    assertValidationError(next.calls[0], 'includeArchived');
+});
+
+test('listMyImages responds with status 200', async () => {
+    const { controller } = createControllerContext();
+    const res = createResponse();
+
+    await controller.listMyImages({ query: {} }, res, createNext());
+
+    assert.equal(res.statusCode, 200);
+});
+
+test('listMyImages responds with { images }', async () => {
+    const images = [{ id: 'image-1' }];
+    const { controller } = createControllerContext({ images });
+    const res = createResponse();
+
+    await controller.listMyImages({ query: {} }, res, createNext());
+
+    assert.deepEqual(res.body, { images });
+});
+
+test('listMyImages calls next(error) when auth throws', async () => {
+    const authError = new Error('auth failed');
+    const { controller } = createControllerContext({ requireUserError: authError });
+    const next = createNext();
+
+    await controller.listMyImages({ query: {} }, createResponse(), next);
+
+    assert.equal(next.calls[0], authError);
+});
+
+test('listMyImages calls next(error) when service throws', async () => {
+    const serviceError = new Error('service failed');
+    const { controller } = createControllerContext({ listUserImagesError: serviceError });
+    const next = createNext();
+
+    await controller.listMyImages({ query: {} }, createResponse(), next);
+
+    assert.equal(next.calls[0], serviceError);
+});
+
+test('updateImageVisibility authenticates with authProvider.requireUser(req)', async () => {
+    const { controller, authProvider } = createControllerContext();
+    const req = { params: { imageId: 'image-1' }, body: { isPublic: false } };
+
+    await controller.updateImageVisibility(req, createResponse(), createNext());
+
+    assert.equal(authProvider.calls[0], req);
+});
+
+test('updateImageVisibility calls imageService.updateImageVisibility', async () => {
+    const { controller, imageService, currentUser } = createControllerContext();
+
+    await controller.updateImageVisibility({
+        params: { imageId: 'image-1' },
+        body: { isPublic: false },
+    }, createResponse(), createNext());
+
+    assert.deepEqual(imageService.calls[0], {
+        method: 'updateImageVisibility',
+        imageId: 'image-1',
+        user: currentUser,
+        isPublic: false,
+    });
+});
+
+test('updateImageVisibility responds with status 200 and { image }', async () => {
+    const updatedImage = { id: 'image-1', isPublic: false };
+    const { controller } = createControllerContext({ updatedImage });
+    const res = createResponse();
+
+    await controller.updateImageVisibility({
+        params: { imageId: 'image-1' },
+        body: { isPublic: false },
+    }, res, createNext());
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body, { image: updatedImage });
+});
+
+test('updateImageVisibility validates boolean isPublic', async () => {
+    const { controller } = createControllerContext();
+    const next = createNext();
+
+    await controller.updateImageVisibility({
+        params: { imageId: 'image-1' },
+        body: { isPublic: 'false' },
+    }, createResponse(), next);
+
+    assertValidationError(next.calls[0], 'isPublic');
+});
+
+test('updateImageVisibility returns 404 when service returns null', async () => {
+    const { controller } = createControllerContext({ updatedImage: null });
+    const res = createResponse();
+
+    await controller.updateImageVisibility({
+        params: { imageId: 'missing' },
+        body: { isPublic: false },
+    }, res, createNext());
+
+    assert.equal(res.statusCode, 404);
+    assert.deepEqual(res.body, { error: 'Image not found' });
+});
+
+test('archiveImage authenticates and returns { image }', async () => {
+    const updatedImage = { id: 'image-1', isArchived: true };
+    const { controller, imageService, currentUser } = createControllerContext({ updatedImage });
+    const req = { params: { imageId: 'image-1' } };
+    const res = createResponse();
+
+    await controller.archiveImage(req, res, createNext());
+
+    assert.equal(imageService.calls[0].method, 'archiveImage');
+    assert.equal(imageService.calls[0].user, currentUser);
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body, { image: updatedImage });
+});
+
+test('unarchiveImage authenticates and returns { image }', async () => {
+    const updatedImage = { id: 'image-1', isArchived: false };
+    const { controller, imageService, currentUser } = createControllerContext({ updatedImage });
+    const req = { params: { imageId: 'image-1' } };
+    const res = createResponse();
+
+    await controller.unarchiveImage(req, res, createNext());
+
+    assert.equal(imageService.calls[0].method, 'unarchiveImage');
+    assert.equal(imageService.calls[0].user, currentUser);
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body, { image: updatedImage });
+});
+
+test('archiveImage rejects missing imageId', async () => {
+    const { controller } = createControllerContext();
+    const next = createNext();
+
+    await controller.archiveImage({ params: {} }, createResponse(), next);
+
+    assertValidationError(next.calls[0], 'imageId');
+});
+
+test('unarchiveImage calls next(error) when service throws', async () => {
+    const serviceError = new Error('service failed');
+    const { controller } = createControllerContext({ unarchiveImageError: serviceError });
+    const next = createNext();
+
+    await controller.unarchiveImage({ params: { imageId: 'image-1' } }, createResponse(), next);
+
+    assert.equal(next.calls[0], serviceError);
+});
+
+test('deleteImage reads imageId from req.params.imageId', async () => {
+    const { controller, imageService } = createControllerContext();
+
+    await controller.deleteImage({ params: { imageId: 'image-123' } }, createResponse(), createNext());
+
+    assert.equal(imageService.calls[0].imageId, 'image-123');
+});
+
+test('deleteImage calls authProvider.requireUser(req)', async () => {
+    const { controller, authProvider } = createControllerContext();
+    const req = { params: { imageId: 'image-1' } };
+
+    await controller.deleteImage(req, createResponse(), createNext());
+
+    assert.equal(authProvider.calls[0], req);
+});
+
+test('deleteImage calls imageService.deleteImage(imageId, currentUser)', async () => {
+    const { controller, imageService, currentUser } = createControllerContext();
+
+    await controller.deleteImage({ params: { imageId: 'image-1' } }, createResponse(), createNext());
+
+    assert.equal(imageService.calls[0].method, 'deleteImage');
+    assert.equal(imageService.calls[0].imageId, 'image-1');
+    assert.equal(imageService.calls[0].user, currentUser);
+});
+
+test('deleteImage responds with status 200', async () => {
+    const { controller } = createControllerContext();
+    const res = createResponse();
+
+    await controller.deleteImage({ params: { imageId: 'image-1' } }, res, createNext());
+
+    assert.equal(res.statusCode, 200);
+});
+
+test('deleteImage responds with the delete result', async () => {
+    const deleteResult = { imageId: 'image-1', deleted: true };
+    const { controller } = createControllerContext({ deleteResult });
+    const res = createResponse();
+
+    await controller.deleteImage({ params: { imageId: 'image-1' } }, res, createNext());
+
+    assert.deepEqual(res.body, deleteResult);
+});
+
+test('deleteImage rejects missing imageId', async () => {
+    const { controller } = createControllerContext();
+    const next = createNext();
+
+    await controller.deleteImage({ params: {} }, createResponse(), next);
+
+    assertValidationError(next.calls[0], 'imageId');
+});
+
+test('deleteImage rejects empty imageId', async () => {
+    const { controller } = createControllerContext();
+    const next = createNext();
+
+    await controller.deleteImage({ params: { imageId: '' } }, createResponse(), next);
+
+    assertValidationError(next.calls[0], 'imageId');
+});
+
+test('deleteImage calls next(error) when auth throws', async () => {
+    const authError = new Error('auth failed');
+    const { controller } = createControllerContext({ requireUserError: authError });
+    const next = createNext();
+
+    await controller.deleteImage({ params: { imageId: 'image-1' } }, createResponse(), next);
+
+    assert.equal(next.calls[0], authError);
+});
+
+test('deleteImage calls next(error) when service throws', async () => {
+    const serviceError = new Error('service failed');
+    const { controller } = createControllerContext({ deleteImageError: serviceError });
+    const next = createNext();
+
+    await controller.deleteImage({ params: { imageId: 'image-1' } }, createResponse(), next);
+
+    assert.equal(next.calls[0], serviceError);
+});
+
+test('uploadImage authenticates with authProvider.requireUser(req)', async () => {
+    const { controller, authProvider } = createControllerContext();
+    const req = { file: { path: '/tmp/file' }, body: {} };
+
+    await controller.uploadImage(req, createResponse(), createNext());
+
+    assert.equal(authProvider.calls[0], req);
+});
+
+test('uploadImage passes req.file, currentUser, and req.body to upload service', async () => {
+    const { controller, imageUploadService, currentUser } = createControllerContext();
+    const file = { path: '/tmp/file' };
+    const body = { title: 'Upload' };
+
+    await controller.uploadImage({ file, body }, createResponse(), createNext());
+
+    assert.deepEqual(imageUploadService.calls[0], {
+        file,
+        currentUser,
+        fields: body,
+    });
+});
+
+test('uploadImage responds with status 201', async () => {
+    const { controller } = createControllerContext();
+    const res = createResponse();
+
+    await controller.uploadImage({ file: {}, body: {} }, res, createNext());
+
+    assert.equal(res.statusCode, 201);
+});
+
+test('uploadImage responds with { image }', async () => {
+    const uploadedImage = { id: 'image-2', imageUrl: 'http://localhost/media/image-2.webp' };
+    const { controller } = createControllerContext({ uploadedImage });
+    const res = createResponse();
+
+    await controller.uploadImage({ file: {}, body: {} }, res, createNext());
+
+    assert.deepEqual(res.body, { image: uploadedImage });
+});
+
+test('uploadImage calls next(error) when auth fails', async () => {
+    const authError = new Error('auth failed');
+    const { controller } = createControllerContext({ requireUserError: authError });
+    const next = createNext();
+
+    await controller.uploadImage({ file: {}, body: {} }, createResponse(), next);
+
+    assert.equal(next.calls[0], authError);
+});
+
+test('uploadImage calls next(error) when upload service fails', async () => {
+    const uploadError = new Error('upload failed');
+    const { controller } = createControllerContext({ uploadImageError: uploadError });
+    const next = createNext();
+
+    await controller.uploadImage({ file: {}, body: {} }, createResponse(), next);
+
+    assert.equal(next.calls[0], uploadError);
+});
+
+test('uploadImage does not call upload service when auth fails', async () => {
+    const authError = new Error('auth failed');
+    const { controller, imageUploadService } = createControllerContext({ requireUserError: authError });
+
+    await controller.uploadImage({ file: {}, body: {} }, createResponse(), createNext());
+
+    assert.equal(imageUploadService.calls.length, 0);
+});
+
+test('invalid limit produces validation error with statusCode = 400', async () => {
+    const { controller } = createControllerContext();
+    const next = createNext();
+
+    await controller.listPublicImages({ query: { limit: '0' } }, createResponse(), next);
+
+    assert.equal(next.calls[0].statusCode, 400);
+});
+
+test('invalid limit produces validation error with code = VALIDATION_ERROR', async () => {
+    const { controller } = createControllerContext();
+    const next = createNext();
+
+    await controller.listPublicImages({ query: { limit: '-1' } }, createResponse(), next);
+
+    assert.equal(next.calls[0].code, 'VALIDATION_ERROR');
+});
+
+test('invalid offset produces validation error with statusCode = 400', async () => {
+    const { controller } = createControllerContext();
+    const next = createNext();
+
+    await controller.listPublicImages({ query: { offset: '-1' } }, createResponse(), next);
+
+    assert.equal(next.calls[0].statusCode, 400);
+});
+
+test('invalid offset produces validation error with code = VALIDATION_ERROR', async () => {
+    const { controller } = createControllerContext();
+    const next = createNext();
+
+    await controller.listPublicImages({ query: { offset: '1.5' } }, createResponse(), next);
+
+    assert.equal(next.calls[0].code, 'VALIDATION_ERROR');
+});
+
+test('validation error messages include the relevant input name', async () => {
+    const { controller } = createControllerContext();
+    const limitNext = createNext();
+    const offsetNext = createNext();
+    const imageIdNext = createNext();
+
+    await controller.listPublicImages({ query: { limit: 'abc' } }, createResponse(), limitNext);
+    await controller.listPublicImages({ query: { offset: 'abc' } }, createResponse(), offsetNext);
+    await controller.deleteImage({ params: { imageId: '' } }, createResponse(), imageIdNext);
+
+    assert.match(limitNext.calls[0].message, /limit/);
+    assert.match(offsetNext.calls[0].message, /offset/);
+    assert.match(imageIdNext.calls[0].message, /imageId/);
+});
+
+test('controller rejects invalid pagination cases', async () => {
+    const invalidQueries = [
+        { limit: '0' },
+        { limit: '-1' },
+        { limit: '1.5' },
+        { limit: 'abc' },
+        { limit: '' },
+        { limit: [] },
+        { offset: '-1' },
+        { offset: '1.5' },
+        { offset: 'abc' },
+        { offset: '' },
+        { offset: [] },
+    ];
+
+    for (const query of invalidQueries) {
+        const { controller } = createControllerContext();
+        const next = createNext();
+
+        await controller.listPublicImages({ query }, createResponse(), next);
+
+        assert.equal(next.calls[0].statusCode, 400);
+        assert.equal(next.calls[0].code, 'VALIDATION_ERROR');
+    }
+});
+
+test('controller does not mutate req.query', async () => {
+    const { controller } = createControllerContext();
+    const query = { limit: '10', offset: '2' };
+    const before = JSON.stringify(query);
+
+    await controller.listPublicImages({ query }, createResponse(), createNext());
+
+    assert.equal(JSON.stringify(query), before);
+});
+
+test('controller does not mutate authenticated user object', async () => {
+    const currentUser = { uid: 'user-1', email: 'user@example.com' };
+    const before = JSON.stringify(currentUser);
+    const { controller } = createControllerContext({ currentUser });
+
+    await controller.listMyImages({ query: {} }, createResponse(), createNext());
+
+    assert.equal(JSON.stringify(currentUser), before);
+});

--- a/tests/imageApiRoutes.test.js
+++ b/tests/imageApiRoutes.test.js
@@ -1,0 +1,131 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createImageApiRoutes } = require('../routes/imageApiRoutes');
+
+const createDependencies = () => ({
+    imageService: {
+        listPublicImages: async () => [],
+        listUserImages: async () => [],
+        updateImageVisibility: async (imageId, currentUser, isPublic) => ({ id: imageId, isPublic }),
+        archiveImage: async (imageId) => ({ id: imageId, isArchived: true }),
+        unarchiveImage: async (imageId) => ({ id: imageId, isArchived: false }),
+        deleteImage: async (imageId) => ({ imageId, deleted: true }),
+    },
+    imageUploadService: {
+        uploadImage: async () => ({ id: 'image-1' }),
+    },
+    authProvider: {
+        requireUser: async () => ({ uid: 'user-1' }),
+    },
+});
+
+const getRouteDescriptors = (router) =>
+    router.stack
+        .filter((layer) => layer.route)
+        .map((layer) => ({
+            path: layer.route.path,
+            methods: Object.keys(layer.route.methods).filter((method) => layer.route.methods[method]),
+        }));
+
+const hasRoute = (router, method, path) =>
+    getRouteDescriptors(router).some((route) =>
+        route.path === path && route.methods.includes(method.toLowerCase()));
+
+test('creates an Express router', () => {
+    const router = createImageApiRoutes(createDependencies());
+
+    assert.equal(typeof router, 'function');
+    assert.equal(Array.isArray(router.stack), true);
+});
+
+test('rejects missing dependencies through controller factory validation', () => {
+    assert.throws(
+        () => createImageApiRoutes({}),
+        /imageService/,
+    );
+});
+
+test('registers GET /public', () => {
+    const router = createImageApiRoutes(createDependencies());
+
+    assert.equal(hasRoute(router, 'GET', '/public'), true);
+});
+
+test('registers GET /me', () => {
+    const router = createImageApiRoutes(createDependencies());
+
+    assert.equal(hasRoute(router, 'GET', '/me'), true);
+});
+
+test('registers DELETE /:imageId', () => {
+    const router = createImageApiRoutes(createDependencies());
+
+    assert.equal(hasRoute(router, 'DELETE', '/:imageId'), true);
+});
+
+test('registers POST /', () => {
+    const router = createImageApiRoutes(createDependencies());
+
+    assert.equal(hasRoute(router, 'POST', '/'), true);
+});
+
+test('registers PATCH /:imageId/visibility', () => {
+    const router = createImageApiRoutes(createDependencies());
+
+    assert.equal(hasRoute(router, 'PATCH', '/:imageId/visibility'), true);
+});
+
+test('registers POST /:imageId/archive', () => {
+    const router = createImageApiRoutes(createDependencies());
+
+    assert.equal(hasRoute(router, 'POST', '/:imageId/archive'), true);
+});
+
+test('registers POST /:imageId/unarchive', () => {
+    const router = createImageApiRoutes(createDependencies());
+
+    assert.equal(hasRoute(router, 'POST', '/:imageId/unarchive'), true);
+});
+
+test('POST / is wired with upload middleware when provided', () => {
+    const uploadMiddleware = (req, res, next) => next();
+    Object.defineProperty(uploadMiddleware, 'name', { value: 'fakeUploadSingleImage' });
+    const dependencies = {
+        ...createDependencies(),
+        upload: {
+            single(fieldName) {
+                assert.equal(fieldName, 'image');
+                return uploadMiddleware;
+            },
+        },
+    };
+
+    const router = createImageApiRoutes(dependencies);
+    const postLayer = router.stack.find((layer) => layer.route && layer.route.path === '/');
+    const handlerNames = postLayer.route.stack.map((layer) => layer.handle.name);
+
+    assert.equal(handlerNames.includes('fakeUploadSingleImage'), true);
+});
+
+test('POST / maps to controller upload handler', () => {
+    const router = createImageApiRoutes(createDependencies());
+    const postLayer = router.stack.find((layer) => layer.route && layer.route.path === '/');
+    const handlerNames = postLayer.route.stack.map((layer) => layer.handle.name);
+
+    assert.equal(handlerNames.includes('uploadImage'), true);
+});
+
+test('does not register legacy /resize-upload', () => {
+    const router = createImageApiRoutes(createDependencies());
+    const paths = getRouteDescriptors(router).map((route) => route.path);
+
+    assert.equal(paths.includes('/resize-upload'), false);
+});
+
+test('does not register legacy /delete-image', () => {
+    const router = createImageApiRoutes(createDependencies());
+    const paths = getRouteDescriptors(router).map((route) => route.path);
+
+    assert.equal(paths.includes('/delete-image'), false);
+});

--- a/tests/imageController.test.js
+++ b/tests/imageController.test.js
@@ -32,6 +32,15 @@ const createController = (bucketOverride = null) => {
     });
 };
 
+const createControllerWithBucketGetter = (bucketGetter) => createImageController({
+    bucketGetter,
+    imageProcessor: 'sharp',
+    uploadAcl: 'publicRead',
+    usePredefinedAcl: true,
+    urlMode: 'public',
+    signedUrlExpiresSeconds: 900,
+});
+
 test('deleteImage returns 400 when imgName is missing', async () => {
     const controller = createController();
     const req = { body: {} };
@@ -41,6 +50,21 @@ test('deleteImage returns 400 when imgName is missing', async () => {
 
     assert.equal(res.statusCode, 400);
     assert.equal(res.sent, 'Image name is required');
+});
+
+test('deleteImage does not request Firebase bucket when imgName is missing', async () => {
+    let bucketRequested = false;
+    const controller = createControllerWithBucketGetter(() => {
+        bucketRequested = true;
+        return { file: () => ({ delete: async () => {} }) };
+    });
+    const req = { body: {} };
+    const res = createMockResponse();
+
+    await controller.deleteImage(req, res);
+
+    assert.equal(bucketRequested, false);
+    assert.equal(res.statusCode, 400);
 });
 
 test('deleteImage deletes object and returns 200', async () => {
@@ -62,6 +86,30 @@ test('deleteImage deletes object and returns 200', async () => {
     assert.equal(deletedPath, 'images/abc.jpg');
     assert.equal(res.statusCode, 200);
     assert.equal(res.sent, 'File successfully deleted');
+});
+
+test('deleteImage requests Firebase bucket lazily when storage is needed', async () => {
+    let bucketRequests = 0;
+    let deletedPath = null;
+    const controller = createControllerWithBucketGetter(() => {
+        bucketRequests += 1;
+        return {
+            file: (path) => ({
+                delete: async () => {
+                    deletedPath = path;
+                },
+            }),
+        };
+    });
+
+    const req = { body: { imgName: 'lazy.jpg' } };
+    const res = createMockResponse();
+
+    await controller.deleteImage(req, res);
+
+    assert.equal(bucketRequests, 1);
+    assert.equal(deletedPath, 'images/lazy.jpg');
+    assert.equal(res.statusCode, 200);
 });
 
 test('deleteImage returns 500 when storage delete fails', async () => {

--- a/tests/imagePresenter.test.js
+++ b/tests/imagePresenter.test.js
@@ -1,0 +1,421 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createImagePresenter } = require('../services/imagePresenter');
+
+const createImageRecord = (overrides = {}) => ({
+    id: 'img-1',
+    ownerId: 'owner-1',
+    title: 'Title',
+    description: 'Description',
+    storageKey: 'users/owner-1/images/img-1.webp',
+    thumbnailKey: 'users/owner-1/thumbnails/img-1.webp',
+    mimeType: 'image/webp',
+    width: 1280,
+    height: 720,
+    sizeBytes: 123456,
+    isPublic: true,
+    createdAt: '2026-06-22T00:00:00.000Z',
+    updatedAt: '2026-06-22T01:00:00.000Z',
+    deletedAt: null,
+    ...overrides,
+});
+
+const createStorageProvider = ({ asyncUrls = false } = {}) => {
+    const calls = [];
+    return {
+        calls,
+        getUrl(storageKey, options) {
+            calls.push({ storageKey, options });
+            const url = `https://media.example.test/${encodeURIComponent(storageKey)}`;
+            return asyncUrls ? Promise.resolve(url) : url;
+        },
+    };
+};
+
+const assertPresenterError = async (callback, messagePart) => {
+    await assert.rejects(
+        callback,
+        (error) => error instanceof Error && error.message.includes(messagePart),
+    );
+};
+
+test('creates an image presenter', () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    assert.equal(typeof presenter.toImageDto, 'function');
+    assert.equal(typeof presenter.toImageDtos, 'function');
+});
+
+test('rejects missing storageProvider', () => {
+    assert.throws(
+        () => createImagePresenter(),
+        /storageProvider/,
+    );
+});
+
+test('rejects missing storageProvider.getUrl', () => {
+    assert.throws(
+        () => createImagePresenter({ storageProvider: {} }),
+        /storageProvider\.getUrl/,
+    );
+});
+
+test('rejects missing image record', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    await assertPresenterError(() => presenter.toImageDto(), 'imageRecord');
+});
+
+test('rejects missing image id', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    await assertPresenterError(() => presenter.toImageDto(createImageRecord({ id: '' })), 'imageRecord.id');
+});
+
+test('rejects missing image storageKey', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    await assertPresenterError(() => presenter.toImageDto(createImageRecord({ storageKey: '' })), 'imageRecord.storageKey');
+});
+
+test('rejects missing image createdAt', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    await assertPresenterError(() => presenter.toImageDto(createImageRecord({ createdAt: '' })), 'imageRecord.createdAt');
+});
+
+test('maps a full image record to a frontend DTO', async () => {
+    const storageProvider = createStorageProvider();
+    const presenter = createImagePresenter({ storageProvider });
+
+    const dto = await presenter.toImageDto(createImageRecord());
+
+    assert.deepEqual(dto, {
+        id: 'img-1',
+        ownerId: 'owner-1',
+        title: 'Title',
+        description: 'Description',
+        imageUrl: 'https://media.example.test/users%2Fowner-1%2Fimages%2Fimg-1.webp',
+        thumbnailUrl: 'https://media.example.test/users%2Fowner-1%2Fthumbnails%2Fimg-1.webp',
+        width: 1280,
+        height: 720,
+        sizeBytes: 123456,
+        mimeType: 'image/webp',
+        isPublic: true,
+        isArchived: false,
+        createdAt: '2026-06-22T00:00:00.000Z',
+        updatedAt: '2026-06-22T01:00:00.000Z',
+    });
+});
+
+test('generates imageUrl from storageProvider.getUrl', async () => {
+    const storageProvider = createStorageProvider();
+    const presenter = createImagePresenter({ storageProvider });
+
+    const dto = await presenter.toImageDto(createImageRecord());
+
+    assert.equal(dto.imageUrl, 'https://media.example.test/users%2Fowner-1%2Fimages%2Fimg-1.webp');
+    assert.equal(storageProvider.calls[0].storageKey, 'users/owner-1/images/img-1.webp');
+});
+
+test('generates thumbnailUrl when thumbnailKey exists', async () => {
+    const storageProvider = createStorageProvider();
+    const presenter = createImagePresenter({ storageProvider });
+
+    const dto = await presenter.toImageDto(createImageRecord());
+
+    assert.equal(dto.thumbnailUrl, 'https://media.example.test/users%2Fowner-1%2Fthumbnails%2Fimg-1.webp');
+    assert.equal(storageProvider.calls[1].storageKey, 'users/owner-1/thumbnails/img-1.webp');
+});
+
+test('does not generate thumbnailUrl when thumbnailKey is missing', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({ thumbnailKey: null }));
+
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'thumbnailUrl'), false);
+});
+
+test('does not call getUrl for a thumbnail when thumbnailKey is missing', async () => {
+    const storageProvider = createStorageProvider();
+    const presenter = createImagePresenter({ storageProvider });
+
+    await presenter.toImageDto(createImageRecord({ thumbnailKey: undefined }));
+
+    assert.equal(storageProvider.calls.length, 1);
+});
+
+test('supports getUrl returning a Promise', async () => {
+    const presenter = createImagePresenter({
+        storageProvider: createStorageProvider({ asyncUrls: true }),
+    });
+
+    const dto = await presenter.toImageDto(createImageRecord());
+
+    assert.equal(dto.imageUrl, 'https://media.example.test/users%2Fowner-1%2Fimages%2Fimg-1.webp');
+});
+
+test('supports getUrl returning a string', async () => {
+    const presenter = createImagePresenter({
+        storageProvider: createStorageProvider({ asyncUrls: false }),
+    });
+
+    const dto = await presenter.toImageDto(createImageRecord());
+
+    assert.equal(dto.imageUrl, 'https://media.example.test/users%2Fowner-1%2Fimages%2Fimg-1.webp');
+});
+
+test('passes visibility: public for public images', async () => {
+    const storageProvider = createStorageProvider();
+    const presenter = createImagePresenter({ storageProvider });
+
+    await presenter.toImageDto(createImageRecord({ isPublic: true }));
+
+    assert.equal(storageProvider.calls[0].options.visibility, 'public');
+});
+
+test('passes visibility: private for private images', async () => {
+    const storageProvider = createStorageProvider();
+    const presenter = createImagePresenter({ storageProvider });
+
+    await presenter.toImageDto(createImageRecord({ isPublic: false }));
+
+    assert.equal(storageProvider.calls[0].options.visibility, 'private');
+});
+
+test('passes kind: image for main image URLs', async () => {
+    const storageProvider = createStorageProvider();
+    const presenter = createImagePresenter({ storageProvider });
+
+    await presenter.toImageDto(createImageRecord());
+
+    assert.equal(storageProvider.calls[0].options.kind, 'image');
+});
+
+test('passes kind: thumbnail for thumbnail URLs', async () => {
+    const storageProvider = createStorageProvider();
+    const presenter = createImagePresenter({ storageProvider });
+
+    await presenter.toImageDto(createImageRecord());
+
+    assert.equal(storageProvider.calls[1].options.kind, 'thumbnail');
+});
+
+test('converts isPublic to a boolean', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({ isPublic: 1 }));
+
+    assert.equal(dto.isPublic, true);
+    assert.equal(typeof dto.isPublic, 'boolean');
+});
+
+test('converts archivedAt to isArchived boolean', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const archivedDto = await presenter.toImageDto(createImageRecord({
+        archivedAt: '2026-06-23T00:00:00.000Z',
+    }));
+    const activeDto = await presenter.toImageDto(createImageRecord({ archivedAt: null }));
+
+    assert.equal(archivedDto.isArchived, true);
+    assert.equal(activeDto.isArchived, false);
+});
+
+test('preserves archivedAt when present', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({
+        archivedAt: '2026-06-23T00:00:00.000Z',
+    }));
+
+    assert.equal(dto.archivedAt, '2026-06-23T00:00:00.000Z');
+});
+
+test('preserves ownerId', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({ ownerId: 'owner-2' }));
+
+    assert.equal(dto.ownerId, 'owner-2');
+});
+
+test('preserves title when present', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({ title: 'A title' }));
+
+    assert.equal(dto.title, 'A title');
+});
+
+test('preserves description when present', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({ description: 'A description' }));
+
+    assert.equal(dto.description, 'A description');
+});
+
+test('preserves width, height, sizeBytes, and mimeType when present', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({
+        width: 640,
+        height: 480,
+        sizeBytes: 1000,
+        mimeType: 'image/jpeg',
+    }));
+
+    assert.equal(dto.width, 640);
+    assert.equal(dto.height, 480);
+    assert.equal(dto.sizeBytes, 1000);
+    assert.equal(dto.mimeType, 'image/jpeg');
+});
+
+test('preserves createdAt', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({ createdAt: '2026-01-01T00:00:00.000Z' }));
+
+    assert.equal(dto.createdAt, '2026-01-01T00:00:00.000Z');
+});
+
+test('preserves updatedAt when present', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({ updatedAt: '2026-01-02T00:00:00.000Z' }));
+
+    assert.equal(dto.updatedAt, '2026-01-02T00:00:00.000Z');
+});
+
+test('omits optional fields when their values are null or undefined', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({
+        ownerId: null,
+        title: null,
+        description: undefined,
+        thumbnailKey: null,
+        width: null,
+        height: undefined,
+        sizeBytes: null,
+        mimeType: undefined,
+        updatedAt: null,
+    }));
+
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'ownerId'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'title'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'description'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'thumbnailUrl'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'width'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'height'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'sizeBytes'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'mimeType'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'updatedAt'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'archivedAt'), false);
+});
+
+test('does not expose storageKey', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord());
+
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'storageKey'), false);
+});
+
+test('does not expose thumbnailKey', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord());
+
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'thumbnailKey'), false);
+});
+
+test('does not expose deletedAt', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({ deletedAt: '2026-01-03T00:00:00.000Z' }));
+
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'deletedAt'), false);
+});
+
+test('does not expose originalStorageKey', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({ originalStorageKey: 'internal/original.webp' }));
+
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'originalStorageKey'), false);
+});
+
+test('ignores preexisting imageUrl on the internal record', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({ imageUrl: 'https://internal.example/image.webp' }));
+
+    assert.notEqual(dto.imageUrl, 'https://internal.example/image.webp');
+    assert.equal(dto.imageUrl, 'https://media.example.test/users%2Fowner-1%2Fimages%2Fimg-1.webp');
+});
+
+test('ignores preexisting thumbnailUrl on the internal record', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({ thumbnailUrl: 'https://internal.example/thumb.webp' }));
+
+    assert.notEqual(dto.thumbnailUrl, 'https://internal.example/thumb.webp');
+    assert.equal(dto.thumbnailUrl, 'https://media.example.test/users%2Fowner-1%2Fthumbnails%2Fimg-1.webp');
+});
+
+test('toImageDtos maps multiple records', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dtos = await presenter.toImageDtos([
+        createImageRecord({ id: 'img-1', storageKey: 'one.webp', thumbnailKey: null }),
+        createImageRecord({ id: 'img-2', storageKey: 'two.webp', thumbnailKey: null }),
+    ]);
+
+    assert.equal(dtos.length, 2);
+    assert.equal(dtos[0].id, 'img-1');
+    assert.equal(dtos[1].id, 'img-2');
+});
+
+test('toImageDtos preserves order', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dtos = await presenter.toImageDtos([
+        createImageRecord({ id: 'first', storageKey: 'first.webp', thumbnailKey: null }),
+        createImageRecord({ id: 'second', storageKey: 'second.webp', thumbnailKey: null }),
+        createImageRecord({ id: 'third', storageKey: 'third.webp', thumbnailKey: null }),
+    ]);
+
+    assert.deepEqual(dtos.map((dto) => dto.id), ['first', 'second', 'third']);
+});
+
+test('toImageDtos rejects non-array input', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    await assertPresenterError(() => presenter.toImageDtos({}), 'imageRecords');
+});
+
+test('does not mutate the input image record', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+    const imageRecord = createImageRecord();
+    const before = JSON.stringify(imageRecord);
+
+    await presenter.toImageDto(imageRecord);
+
+    assert.equal(JSON.stringify(imageRecord), before);
+});
+
+test('does not mutate the input image record array', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+    const imageRecords = [
+        createImageRecord({ id: 'img-1', storageKey: 'one.webp', thumbnailKey: null }),
+        createImageRecord({ id: 'img-2', storageKey: 'two.webp', thumbnailKey: null }),
+    ];
+    const before = JSON.stringify(imageRecords);
+
+    await presenter.toImageDtos(imageRecords);
+
+    assert.equal(JSON.stringify(imageRecords), before);
+});

--- a/tests/imageService.test.js
+++ b/tests/imageService.test.js
@@ -1,0 +1,725 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createImageService } = require('../services/imageService');
+
+const createImageRecord = (overrides = {}) => ({
+    id: 'img-1',
+    ownerId: 'user-1',
+    storageKey: 'users/user-1/images/img-1.webp',
+    thumbnailKey: 'users/user-1/thumbnails/img-1.webp',
+    createdAt: '2026-06-22T00:00:00.000Z',
+    ...overrides,
+});
+
+const createDto = (imageRecord) => ({
+    id: imageRecord.id,
+    ownerId: imageRecord.ownerId,
+    imageUrl: `https://media.example.test/${imageRecord.id}`,
+    createdAt: imageRecord.createdAt,
+});
+
+const createFakeRepository = (state = {}, operations = []) => {
+    const calls = [];
+    const repositoryState = {
+        publicImages: state.publicImages || [createImageRecord({ id: 'public-1' })],
+        ownerImages: state.ownerImages || [createImageRecord({ id: 'owner-1' })],
+        foundImage: state.foundImage === undefined ? createImageRecord() : state.foundImage,
+        createdImage: state.createdImage || createImageRecord({ id: 'created-1' }),
+        visibilityImage: state.visibilityImage === undefined
+            ? createImageRecord({ id: 'visibility-1', isPublic: false })
+            : state.visibilityImage,
+        archivedImage: state.archivedImage === undefined
+            ? createImageRecord({
+                id: 'archived-1',
+                archivedAt: '2026-06-23T00:00:00.000Z',
+            })
+            : state.archivedImage,
+        unarchivedImage: state.unarchivedImage === undefined
+            ? createImageRecord({ id: 'unarchived-1', archivedAt: null })
+            : state.unarchivedImage,
+        deleteResult: state.deleteResult === undefined ? { deleted: true } : state.deleteResult,
+    };
+
+    return {
+        calls,
+        async listPublicImages(options) {
+            operations.push('listPublicImages');
+            calls.push({ method: 'listPublicImages', options });
+            return repositoryState.publicImages;
+        },
+        async listImagesByOwner(ownerId, options) {
+            operations.push('listImagesByOwner');
+            calls.push({ method: 'listImagesByOwner', ownerId, options });
+            return repositoryState.ownerImages;
+        },
+        async findImageById(imageId, options) {
+            operations.push(`findImageById:${imageId}`);
+            calls.push({ method: 'findImageById', imageId, options });
+            return repositoryState.foundImage;
+        },
+        async createImage(imageData) {
+            operations.push('createImage');
+            calls.push({ method: 'createImage', imageData });
+            return repositoryState.createdImage;
+        },
+        async updateImageVisibility(imageId, ownerId, isPublic) {
+            operations.push(`updateImageVisibility:${imageId}:${ownerId}:${isPublic}`);
+            calls.push({ method: 'updateImageVisibility', imageId, ownerId, isPublic });
+            return repositoryState.visibilityImage;
+        },
+        async archiveImageById(imageId, ownerId) {
+            operations.push(`archiveImageById:${imageId}:${ownerId}`);
+            calls.push({ method: 'archiveImageById', imageId, ownerId });
+            return repositoryState.archivedImage;
+        },
+        async unarchiveImageById(imageId, ownerId) {
+            operations.push(`unarchiveImageById:${imageId}:${ownerId}`);
+            calls.push({ method: 'unarchiveImageById', imageId, ownerId });
+            return repositoryState.unarchivedImage;
+        },
+        async deleteImageById(imageId, ownerId) {
+            operations.push(`deleteImageById:${imageId}:${ownerId}`);
+            calls.push({ method: 'deleteImageById', imageId, ownerId });
+            return repositoryState.deleteResult;
+        },
+    };
+};
+
+const createFakeStorageProvider = (state = {}, operations = []) => {
+    const calls = [];
+    return {
+        calls,
+        async deleteObject(storageKey) {
+            operations.push(`deleteObject:${storageKey}`);
+            calls.push({ storageKey });
+
+            if (state.throwForStorageKey === storageKey) {
+                throw new Error(`delete failed for ${storageKey}`);
+            }
+
+            return {
+                storageKey,
+                deleted: state.deleted === undefined ? true : state.deleted,
+            };
+        },
+    };
+};
+
+const createFakePresenter = (operations = []) => {
+    const calls = [];
+    return {
+        calls,
+        async toImageDto(imageRecord) {
+            operations.push(`toImageDto:${imageRecord.id}`);
+            calls.push({ method: 'toImageDto', imageRecord });
+            return createDto(imageRecord);
+        },
+        async toImageDtos(imageRecords) {
+            operations.push('toImageDtos');
+            calls.push({ method: 'toImageDtos', imageRecords });
+            return imageRecords.map(createDto);
+        },
+    };
+};
+
+const createDependencies = (state = {}) => {
+    const operations = [];
+    const imageRepository = createFakeRepository(state.repository, operations);
+    const storageProvider = createFakeStorageProvider(state.storage, operations);
+    const imagePresenter = createFakePresenter(operations);
+
+    return {
+        operations,
+        imageRepository,
+        storageProvider,
+        imagePresenter,
+    };
+};
+
+const createServiceContext = (state = {}) => {
+    const dependencies = createDependencies(state);
+    return {
+        ...dependencies,
+        service: createImageService(dependencies),
+    };
+};
+
+const assertHttpError = async (callback, statusCode, code) => {
+    await assert.rejects(
+        callback,
+        (error) => error instanceof Error
+            && error.statusCode === statusCode
+            && error.code === code,
+    );
+};
+
+test('creates an image service', () => {
+    const { service } = createServiceContext();
+
+    assert.equal(typeof service.listPublicImages, 'function');
+    assert.equal(typeof service.listUserImages, 'function');
+    assert.equal(typeof service.findImageById, 'function');
+    assert.equal(typeof service.createImage, 'function');
+    assert.equal(typeof service.deleteImage, 'function');
+});
+
+test('rejects missing imageRepository', () => {
+    const { storageProvider, imagePresenter } = createDependencies();
+
+    assert.throws(
+        () => createImageService({ storageProvider, imagePresenter }),
+        /imageRepository/,
+    );
+});
+
+test('rejects missing storageProvider', () => {
+    const { imageRepository, imagePresenter } = createDependencies();
+
+    assert.throws(
+        () => createImageService({ imageRepository, imagePresenter }),
+        /storageProvider/,
+    );
+});
+
+test('rejects missing imagePresenter', () => {
+    const { imageRepository, storageProvider } = createDependencies();
+
+    assert.throws(
+        () => createImageService({ imageRepository, storageProvider }),
+        /imagePresenter/,
+    );
+});
+
+test('rejects missing required repository methods', () => {
+    const requiredMethods = [
+        'listPublicImages',
+        'listImagesByOwner',
+        'findImageById',
+        'createImage',
+        'updateImageVisibility',
+        'archiveImageById',
+        'unarchiveImageById',
+        'deleteImageById',
+    ];
+
+    for (const methodName of requiredMethods) {
+        const dependencies = createDependencies();
+        dependencies.imageRepository[methodName] = undefined;
+
+        assert.throws(
+            () => createImageService(dependencies),
+            new RegExp(`imageRepository\\.${methodName}`),
+        );
+    }
+});
+
+test('rejects missing storageProvider.deleteObject', () => {
+    const dependencies = createDependencies();
+    dependencies.storageProvider.deleteObject = undefined;
+
+    assert.throws(
+        () => createImageService(dependencies),
+        /storageProvider\.deleteObject/,
+    );
+});
+
+test('rejects missing presenter methods', () => {
+    for (const methodName of ['toImageDto', 'toImageDtos']) {
+        const dependencies = createDependencies();
+        dependencies.imagePresenter[methodName] = undefined;
+
+        assert.throws(
+            () => createImageService(dependencies),
+            new RegExp(`imagePresenter\\.${methodName}`),
+        );
+    }
+});
+
+test('listPublicImages calls repository with options', async () => {
+    const { service, imageRepository } = createServiceContext();
+    const options = { limit: 10, offset: 2 };
+
+    await service.listPublicImages(options);
+
+    assert.equal(imageRepository.calls[0].method, 'listPublicImages');
+    assert.equal(imageRepository.calls[0].options, options);
+});
+
+test('listPublicImages returns presenter DTOs', async () => {
+    const { service } = createServiceContext({
+        repository: {
+            publicImages: [createImageRecord({ id: 'public-1' })],
+        },
+    });
+
+    const dtos = await service.listPublicImages();
+
+    assert.deepEqual(dtos, [
+        {
+            id: 'public-1',
+            ownerId: 'user-1',
+            imageUrl: 'https://media.example.test/public-1',
+            createdAt: '2026-06-22T00:00:00.000Z',
+        },
+    ]);
+});
+
+test('listPublicImages does not mutate options', async () => {
+    const { service } = createServiceContext();
+    const options = { limit: 10 };
+    const before = JSON.stringify(options);
+
+    await service.listPublicImages(options);
+
+    assert.equal(JSON.stringify(options), before);
+});
+
+test('listUserImages requires authenticated user', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.listUserImages(null), 401, 'UNAUTHENTICATED');
+});
+
+test('listUserImages calls repository with currentUser.uid', async () => {
+    const { service, imageRepository } = createServiceContext();
+
+    await service.listUserImages({ uid: 'user-2' }, { ownerId: 'attacker' });
+
+    assert.equal(imageRepository.calls[0].ownerId, 'user-2');
+});
+
+test('listUserImages returns presenter DTOs', async () => {
+    const { service } = createServiceContext({
+        repository: {
+            ownerImages: [createImageRecord({ id: 'owned-1' })],
+        },
+    });
+
+    const dtos = await service.listUserImages({ uid: 'user-1' });
+
+    assert.equal(dtos[0].id, 'owned-1');
+    assert.equal(Object.prototype.hasOwnProperty.call(dtos[0], 'storageKey'), false);
+});
+
+test('listUserImages does not mutate currentUser', async () => {
+    const { service } = createServiceContext();
+    const currentUser = { uid: 'user-1', email: 'user@example.com' };
+    const before = JSON.stringify(currentUser);
+
+    await service.listUserImages(currentUser);
+
+    assert.equal(JSON.stringify(currentUser), before);
+});
+
+test('listUserImages does not mutate options', async () => {
+    const { service } = createServiceContext();
+    const options = { limit: 5 };
+    const before = JSON.stringify(options);
+
+    await service.listUserImages({ uid: 'user-1' }, options);
+
+    assert.equal(JSON.stringify(options), before);
+});
+
+test('findImageById requires image id', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.findImageById(''), 400, 'VALIDATION_ERROR');
+});
+
+test('findImageById returns null when repository returns null', async () => {
+    const { service } = createServiceContext({
+        repository: {
+            foundImage: null,
+        },
+    });
+
+    const dto = await service.findImageById('missing');
+
+    assert.equal(dto, null);
+});
+
+test('findImageById returns presenter DTO when image exists', async () => {
+    const { service } = createServiceContext({
+        repository: {
+            foundImage: createImageRecord({ id: 'img-found' }),
+        },
+    });
+
+    const dto = await service.findImageById('img-found');
+
+    assert.equal(dto.id, 'img-found');
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'storageKey'), false);
+});
+
+test('createImage requires authenticated user', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.createImage({ id: 'img-1', storageKey: 'image.webp' }, null), 401, 'UNAUTHENTICATED');
+});
+
+test('createImage requires imageData', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.createImage(null, { uid: 'user-1' }), 400, 'VALIDATION_ERROR');
+});
+
+test('createImage requires imageData.id', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.createImage({ storageKey: 'image.webp' }, { uid: 'user-1' }), 400, 'VALIDATION_ERROR');
+});
+
+test('createImage requires imageData.storageKey', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.createImage({ id: 'img-1' }, { uid: 'user-1' }), 400, 'VALIDATION_ERROR');
+});
+
+test('createImage sets ownerId from currentUser.uid', async () => {
+    const { service, imageRepository } = createServiceContext();
+
+    await service.createImage({ id: 'img-1', storageKey: 'image.webp' }, { uid: 'user-1' });
+
+    assert.equal(imageRepository.calls[0].imageData.ownerId, 'user-1');
+});
+
+test('createImage ignores/overrides imageData.ownerId', async () => {
+    const { service, imageRepository } = createServiceContext();
+
+    await service.createImage({ id: 'img-1', ownerId: 'attacker', storageKey: 'image.webp' }, { uid: 'user-1' });
+
+    assert.equal(imageRepository.calls[0].imageData.ownerId, 'user-1');
+});
+
+test('createImage does not mutate imageData', async () => {
+    const { service } = createServiceContext();
+    const imageData = { id: 'img-1', ownerId: 'attacker', storageKey: 'image.webp' };
+    const before = JSON.stringify(imageData);
+
+    await service.createImage(imageData, { uid: 'user-1' });
+
+    assert.equal(JSON.stringify(imageData), before);
+});
+
+test('createImage returns presenter DTO', async () => {
+    const { service } = createServiceContext({
+        repository: {
+            createdImage: createImageRecord({ id: 'created-1' }),
+        },
+    });
+
+    const dto = await service.createImage({ id: 'created-1', storageKey: 'image.webp' }, { uid: 'user-1' });
+
+    assert.equal(dto.id, 'created-1');
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'storageKey'), false);
+});
+
+test('updateImageVisibility requires authenticated user', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.updateImageVisibility('img-1', null, false), 401, 'UNAUTHENTICATED');
+});
+
+test('updateImageVisibility requires boolean isPublic', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.updateImageVisibility('img-1', { uid: 'user-1' }, 'false'), 400, 'VALIDATION_ERROR');
+});
+
+test('updateImageVisibility uses currentUser.uid', async () => {
+    const { service, imageRepository } = createServiceContext();
+
+    await service.updateImageVisibility('img-1', { uid: 'user-2' }, false);
+
+    assert.equal(imageRepository.calls[0].method, 'updateImageVisibility');
+    assert.equal(imageRepository.calls[0].ownerId, 'user-2');
+    assert.equal(imageRepository.calls[0].isPublic, false);
+});
+
+test('updateImageVisibility returns presenter DTO', async () => {
+    const { service } = createServiceContext({
+        repository: {
+            visibilityImage: createImageRecord({ id: 'visibility-1', isPublic: false }),
+        },
+    });
+
+    const dto = await service.updateImageVisibility('visibility-1', { uid: 'user-1' }, false);
+
+    assert.equal(dto.id, 'visibility-1');
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'storageKey'), false);
+});
+
+test('updateImageVisibility returns null when repository returns null', async () => {
+    const { service } = createServiceContext({
+        repository: {
+            visibilityImage: null,
+        },
+    });
+
+    assert.equal(await service.updateImageVisibility('missing', { uid: 'user-1' }, false), null);
+});
+
+test('archiveImage requires authenticated user', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.archiveImage('img-1', null), 401, 'UNAUTHENTICATED');
+});
+
+test('archiveImage uses currentUser.uid', async () => {
+    const { service, imageRepository } = createServiceContext();
+
+    await service.archiveImage('img-1', { uid: 'user-2' });
+
+    assert.equal(imageRepository.calls[0].method, 'archiveImageById');
+    assert.equal(imageRepository.calls[0].ownerId, 'user-2');
+});
+
+test('archiveImage returns presenter DTO', async () => {
+    const { service } = createServiceContext({
+        repository: {
+            archivedImage: createImageRecord({
+                id: 'archived-1',
+                archivedAt: '2026-06-23T00:00:00.000Z',
+            }),
+        },
+    });
+
+    const dto = await service.archiveImage('archived-1', { uid: 'user-1' });
+
+    assert.equal(dto.id, 'archived-1');
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'storageKey'), false);
+});
+
+test('unarchiveImage requires authenticated user', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.unarchiveImage('img-1', null), 401, 'UNAUTHENTICATED');
+});
+
+test('unarchiveImage uses currentUser.uid', async () => {
+    const { service, imageRepository } = createServiceContext();
+
+    await service.unarchiveImage('img-1', { uid: 'user-2' });
+
+    assert.equal(imageRepository.calls[0].method, 'unarchiveImageById');
+    assert.equal(imageRepository.calls[0].ownerId, 'user-2');
+});
+
+test('unarchiveImage returns presenter DTO', async () => {
+    const { service } = createServiceContext({
+        repository: {
+            unarchivedImage: createImageRecord({ id: 'unarchived-1', archivedAt: null }),
+        },
+    });
+
+    const dto = await service.unarchiveImage('unarchived-1', { uid: 'user-1' });
+
+    assert.equal(dto.id, 'unarchived-1');
+    assert.equal(Object.prototype.hasOwnProperty.call(dto, 'storageKey'), false);
+});
+
+test('archive and visibility updates do not delete storage objects', async () => {
+    const { service, storageProvider } = createServiceContext();
+
+    await service.updateImageVisibility('img-1', { uid: 'user-1' }, false);
+    await service.archiveImage('img-1', { uid: 'user-1' });
+    await service.unarchiveImage('img-1', { uid: 'user-1' });
+
+    assert.equal(storageProvider.calls.length, 0);
+});
+
+test('deleteImage requires image id', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.deleteImage('', { uid: 'user-1' }), 400, 'VALIDATION_ERROR');
+});
+
+test('deleteImage requires authenticated user', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.deleteImage('img-1', null), 401, 'UNAUTHENTICATED');
+});
+
+test('deleteImage returns { deleted: false } when image does not exist', async () => {
+    const { service, storageProvider, imageRepository } = createServiceContext({
+        repository: {
+            foundImage: null,
+        },
+    });
+
+    const result = await service.deleteImage('missing', { uid: 'user-1' });
+
+    assert.deepEqual(result, { imageId: 'missing', deleted: false });
+    assert.equal(storageProvider.calls.length, 0);
+    assert.equal(imageRepository.calls.some((call) => call.method === 'deleteImageById'), false);
+});
+
+test('deleteImage throws forbidden when owner does not match', async () => {
+    const { service } = createServiceContext({
+        repository: {
+            foundImage: createImageRecord({ ownerId: 'other-user' }),
+        },
+    });
+
+    await assertHttpError(() => service.deleteImage('img-1', { uid: 'user-1' }), 403, 'FORBIDDEN');
+});
+
+test('deleteImage deletes main storage object', async () => {
+    const { service, storageProvider } = createServiceContext();
+
+    await service.deleteImage('img-1', { uid: 'user-1' });
+
+    assert.equal(storageProvider.calls[0].storageKey, 'users/user-1/images/img-1.webp');
+});
+
+test('deleteImage deletes thumbnail storage object when present', async () => {
+    const { service, storageProvider } = createServiceContext();
+
+    await service.deleteImage('img-1', { uid: 'user-1' });
+
+    assert.equal(storageProvider.calls[1].storageKey, 'users/user-1/thumbnails/img-1.webp');
+});
+
+test('deleteImage does not delete thumbnail when thumbnailKey is missing', async () => {
+    const { service, storageProvider } = createServiceContext({
+        repository: {
+            foundImage: createImageRecord({ thumbnailKey: null }),
+        },
+    });
+
+    await service.deleteImage('img-1', { uid: 'user-1' });
+
+    assert.equal(storageProvider.calls.length, 1);
+});
+
+test('deleteImage soft-deletes metadata after storage deletion', async () => {
+    const { service, operations } = createServiceContext();
+
+    await service.deleteImage('img-1', { uid: 'user-1' });
+
+    assert.equal(operations[operations.length - 1], 'deleteImageById:img-1:user-1');
+});
+
+test('deleteImage calls storage deletion before metadata soft-delete', async () => {
+    const { service, operations } = createServiceContext();
+
+    await service.deleteImage('img-1', { uid: 'user-1' });
+
+    assert.deepEqual(operations, [
+        'findImageById:img-1',
+        'deleteObject:users/user-1/images/img-1.webp',
+        'deleteObject:users/user-1/thumbnails/img-1.webp',
+        'deleteImageById:img-1:user-1',
+    ]);
+});
+
+test('deleteImage returns repository delete result as boolean', async () => {
+    const { service } = createServiceContext({
+        repository: {
+            deleteResult: { deleted: 1 },
+        },
+    });
+
+    const result = await service.deleteImage('img-1', { uid: 'user-1' });
+
+    assert.deepEqual(result, { imageId: 'img-1', deleted: true });
+});
+
+test('deleteImage continues metadata soft-delete when storage object is already missing', async () => {
+    const { service, imageRepository } = createServiceContext({
+        storage: {
+            deleted: false,
+        },
+    });
+
+    const result = await service.deleteImage('img-1', { uid: 'user-1' });
+
+    assert.equal(result.deleted, true);
+    assert.equal(imageRepository.calls.some((call) => call.method === 'deleteImageById'), true);
+});
+
+test('deleteImage propagates main storage deletion errors', async () => {
+    const { service } = createServiceContext({
+        storage: {
+            throwForStorageKey: 'users/user-1/images/img-1.webp',
+        },
+    });
+
+    await assert.rejects(
+        () => service.deleteImage('img-1', { uid: 'user-1' }),
+        /delete failed/,
+    );
+});
+
+test('deleteImage propagates thumbnail deletion errors', async () => {
+    const { service } = createServiceContext({
+        storage: {
+            throwForStorageKey: 'users/user-1/thumbnails/img-1.webp',
+        },
+    });
+
+    await assert.rejects(
+        () => service.deleteImage('img-1', { uid: 'user-1' }),
+        /delete failed/,
+    );
+});
+
+test('deleteImage does not soft-delete metadata when main storage deletion fails', async () => {
+    const { service, imageRepository } = createServiceContext({
+        storage: {
+            throwForStorageKey: 'users/user-1/images/img-1.webp',
+        },
+    });
+
+    await assert.rejects(() => service.deleteImage('img-1', { uid: 'user-1' }));
+
+    assert.equal(imageRepository.calls.some((call) => call.method === 'deleteImageById'), false);
+});
+
+test('deleteImage does not soft-delete metadata when thumbnail deletion fails', async () => {
+    const { service, imageRepository } = createServiceContext({
+        storage: {
+            throwForStorageKey: 'users/user-1/thumbnails/img-1.webp',
+        },
+    });
+
+    await assert.rejects(() => service.deleteImage('img-1', { uid: 'user-1' }));
+
+    assert.equal(imageRepository.calls.some((call) => call.method === 'deleteImageById'), false);
+});
+
+test('validation errors include statusCode = 400 and code = VALIDATION_ERROR', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.findImageById(''), 400, 'VALIDATION_ERROR');
+});
+
+test('missing authenticated user errors include statusCode = 401 and code = UNAUTHENTICATED', async () => {
+    const { service } = createServiceContext();
+
+    await assertHttpError(() => service.listUserImages({ uid: '' }), 401, 'UNAUTHENTICATED');
+});
+
+test('owner mismatch errors include statusCode = 403 and code = FORBIDDEN', async () => {
+    const { service } = createServiceContext({
+        repository: {
+            foundImage: createImageRecord({ ownerId: 'other-user' }),
+        },
+    });
+
+    await assertHttpError(() => service.deleteImage('img-1', { uid: 'user-1' }), 403, 'FORBIDDEN');
+});
+
+test('service does not expose internal storage keys in returned DTOs', async () => {
+    const { service } = createServiceContext();
+
+    const dtos = await service.listPublicImages();
+    const created = await service.createImage({ id: 'img-1', storageKey: 'internal.webp' }, { uid: 'user-1' });
+    const found = await service.findImageById('img-1');
+
+    assert.equal(Object.prototype.hasOwnProperty.call(dtos[0], 'storageKey'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(created, 'storageKey'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(found, 'storageKey'), false);
+});

--- a/tests/imageUploadService.test.js
+++ b/tests/imageUploadService.test.js
@@ -1,0 +1,467 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createImageUploadService } = require('../services/imageUploadService');
+
+const createConfig = (overrides = {}) => ({
+    imageProcessor: 'sharp',
+    maxFileSizeBytes: 5 * 1024 * 1024,
+    lowMemoryMode: true,
+    ...overrides,
+});
+
+const createFile = (overrides = {}) => ({
+    path: '/tmp/photogram-test-upload',
+    mimetype: 'image/jpeg',
+    size: 1234,
+    originalname: 'original-name.jpg',
+    ...overrides,
+});
+
+const createCurrentUser = (overrides = {}) => ({
+    uid: 'user-1',
+    email: 'user@example.com',
+    ...overrides,
+});
+
+const createProcessedImage = (overrides = {}) => ({
+    buffer: Buffer.from('processed-main'),
+    mimeType: 'image/jpeg',
+    extension: 'jpg',
+    width: 1440,
+    height: 960,
+    sizeBytes: 14,
+    ...overrides,
+});
+
+const createDependencies = (overrides = {}) => {
+    const storageCalls = [];
+    const imageServiceCalls = [];
+    const processorCalls = [];
+    const dto = overrides.dto || {
+        id: 'image-1',
+        imageUrl: 'http://localhost:3000/media/users/user-1/images/image-1.jpg',
+    };
+
+    const storageProvider = {
+        calls: storageCalls,
+        async saveObject(input) {
+            storageCalls.push({ method: 'saveObject', input });
+            if (overrides.throwOnSaveKey && input.storageKey === overrides.throwOnSaveKey) {
+                throw overrides.saveError || new Error('save failed');
+            }
+            return {
+                storageKey: input.storageKey,
+                sizeBytes: Buffer.isBuffer(input.buffer) ? input.buffer.length : 10,
+            };
+        },
+        async deleteObject(storageKey) {
+            storageCalls.push({ method: 'deleteObject', storageKey });
+            if (overrides.deleteError) {
+                throw overrides.deleteError;
+            }
+            return { storageKey, deleted: true };
+        },
+    };
+
+    const imageService = {
+        calls: imageServiceCalls,
+        async createImage(imageData, currentUser) {
+            imageServiceCalls.push({ imageData, currentUser });
+            if (overrides.metadataError) {
+                throw overrides.metadataError;
+            }
+            return dto;
+        },
+    };
+
+    const imageProcessor = {
+        calls: processorCalls,
+        async processImage(file, options) {
+            processorCalls.push({ file, options });
+            if (overrides.processingError) {
+                throw overrides.processingError;
+            }
+            return overrides.processed || createProcessedImage();
+        },
+    };
+
+    const service = createImageUploadService({
+        config: overrides.config || createConfig(),
+        storageProvider,
+        imageService,
+        imageProcessor,
+        idGenerator: overrides.idGenerator || (() => 'image-1'),
+    });
+
+    return {
+        service,
+        storageProvider,
+        imageService,
+        imageProcessor,
+        dto,
+    };
+};
+
+const uploadWithDefaults = (service, overrides = {}) => service.uploadImage({
+    file: overrides.file || createFile(),
+    currentUser: Object.prototype.hasOwnProperty.call(overrides, 'currentUser')
+        ? overrides.currentUser
+        : createCurrentUser(),
+    fields: overrides.fields || {},
+});
+
+test('creates an image upload service', () => {
+    const { service } = createDependencies();
+
+    assert.equal(typeof service.uploadImage, 'function');
+});
+
+test('rejects missing config', () => {
+    const { storageProvider, imageService, imageProcessor } = createDependencies();
+
+    assert.throws(
+        () => createImageUploadService({ storageProvider, imageService, imageProcessor }),
+        /config/,
+    );
+});
+
+test('rejects missing storageProvider', () => {
+    const { imageService, imageProcessor } = createDependencies();
+
+    assert.throws(
+        () => createImageUploadService({ config: createConfig(), imageService, imageProcessor }),
+        /storageProvider/,
+    );
+});
+
+test('rejects missing storageProvider.saveObject', () => {
+    const { imageService, imageProcessor } = createDependencies();
+
+    assert.throws(
+        () => createImageUploadService({
+            config: createConfig(),
+            storageProvider: {},
+            imageService,
+            imageProcessor,
+        }),
+        /storageProvider\.saveObject/,
+    );
+});
+
+test('rejects missing imageService', () => {
+    const { storageProvider, imageProcessor } = createDependencies();
+
+    assert.throws(
+        () => createImageUploadService({ config: createConfig(), storageProvider, imageProcessor }),
+        /imageService/,
+    );
+});
+
+test('rejects missing imageService.createImage', () => {
+    const { storageProvider, imageProcessor } = createDependencies();
+
+    assert.throws(
+        () => createImageUploadService({
+            config: createConfig(),
+            storageProvider,
+            imageService: {},
+            imageProcessor,
+        }),
+        /imageService\.createImage/,
+    );
+});
+
+test('rejects missing imageProcessor', () => {
+    const { storageProvider, imageService } = createDependencies();
+
+    assert.throws(
+        () => createImageUploadService({ config: createConfig(), storageProvider, imageService }),
+        /imageProcessor\.processImage/,
+    );
+});
+
+test('rejects missing authenticated user', async () => {
+    const { service } = createDependencies();
+
+    await assert.rejects(
+        () => uploadWithDefaults(service, { currentUser: null }),
+        /currentUser\.uid/,
+    );
+});
+
+test('rejects missing file', async () => {
+    const { service } = createDependencies();
+
+    await assert.rejects(
+        () => service.uploadImage({ currentUser: createCurrentUser(), fields: {} }),
+        /file/,
+    );
+});
+
+test('calls imageProcessor with uploaded file and config-derived options', async () => {
+    const config = createConfig({ maxFileSizeBytes: 2048, lowMemoryMode: true, imageProcessor: 'jimp' });
+    const { service, imageProcessor } = createDependencies({ config });
+    const file = createFile();
+
+    await uploadWithDefaults(service, { file });
+
+    assert.equal(imageProcessor.calls[0].file, file);
+    assert.equal(imageProcessor.calls[0].options.config, config);
+    assert.equal(imageProcessor.calls[0].options.maxWidth, 1440);
+    assert.equal(imageProcessor.calls[0].options.quality, 80);
+    assert.equal(imageProcessor.calls[0].options.imageProcessor, 'jimp');
+    assert.equal(imageProcessor.calls[0].options.maxFileSizeBytes, 2048);
+    assert.equal(imageProcessor.calls[0].options.lowMemoryMode, true);
+});
+
+test('generates deterministic storage keys using uid and image id', async () => {
+    const { service, storageProvider } = createDependencies();
+
+    await uploadWithDefaults(service);
+
+    assert.equal(storageProvider.calls[0].input.storageKey, 'users/user-1/images/image-1.jpg');
+});
+
+test('does not use original filename in storage key', async () => {
+    const { service, storageProvider } = createDependencies();
+
+    await uploadWithDefaults(service, {
+        file: createFile({ originalname: 'do-not-use-this-name.png' }),
+    });
+
+    assert.equal(storageProvider.calls[0].input.storageKey.includes('do-not-use-this-name'), false);
+});
+
+test('saves processed main image through storageProvider.saveObject', async () => {
+    const { service, storageProvider } = createDependencies();
+
+    await uploadWithDefaults(service);
+
+    assert.equal(storageProvider.calls[0].method, 'saveObject');
+    assert.equal(storageProvider.calls[0].input.buffer.toString(), 'processed-main');
+});
+
+test('saves thumbnail when processor returns thumbnail output', async () => {
+    const { service, storageProvider } = createDependencies({
+        processed: createProcessedImage({
+            thumbnailBuffer: Buffer.from('processed-thumb'),
+            thumbnailExtension: 'webp',
+            thumbnailSizeBytes: 15,
+        }),
+    });
+
+    await uploadWithDefaults(service);
+
+    assert.equal(storageProvider.calls[1].method, 'saveObject');
+    assert.equal(storageProvider.calls[1].input.storageKey, 'users/user-1/thumbnails/image-1.webp');
+});
+
+test('does not save thumbnail when processor does not return thumbnail output', async () => {
+    const { service, storageProvider } = createDependencies();
+
+    await uploadWithDefaults(service);
+
+    assert.equal(storageProvider.calls.filter((call) => call.method === 'saveObject').length, 1);
+});
+
+test('calls imageService.createImage with metadata', async () => {
+    const { service, imageService } = createDependencies();
+
+    await uploadWithDefaults(service);
+
+    assert.deepEqual(imageService.calls[0].imageData, {
+        id: 'image-1',
+        title: undefined,
+        description: undefined,
+        storageKey: 'users/user-1/images/image-1.jpg',
+        thumbnailKey: null,
+        mimeType: 'image/jpeg',
+        width: 1440,
+        height: 960,
+        sizeBytes: 14,
+        isPublic: true,
+    });
+});
+
+test('sets owner through imageService/currentUser, not request fields', async () => {
+    const currentUser = createCurrentUser({ uid: 'user-1' });
+    const { service, imageService } = createDependencies();
+
+    await uploadWithDefaults(service, {
+        currentUser,
+        fields: { ownerId: 'attacker' },
+    });
+
+    assert.equal(Object.prototype.hasOwnProperty.call(imageService.calls[0].imageData, 'ownerId'), false);
+    assert.equal(imageService.calls[0].currentUser, currentUser);
+});
+
+test('passes title and description from fields', async () => {
+    const { service, imageService } = createDependencies();
+
+    await uploadWithDefaults(service, {
+        fields: {
+            title: 'Test upload',
+            description: 'Uploaded through provider API',
+        },
+    });
+
+    assert.equal(imageService.calls[0].imageData.title, 'Test upload');
+    assert.equal(imageService.calls[0].imageData.description, 'Uploaded through provider API');
+});
+
+test('defaults isPublic to true', async () => {
+    const { service, imageService } = createDependencies();
+
+    await uploadWithDefaults(service);
+
+    assert.equal(imageService.calls[0].imageData.isPublic, true);
+});
+
+test('parses isPublic false', async () => {
+    const { service, imageService } = createDependencies();
+
+    await uploadWithDefaults(service, {
+        fields: { isPublic: 'false' },
+    });
+
+    assert.equal(imageService.calls[0].imageData.isPublic, false);
+});
+
+test('rejects invalid isPublic', async () => {
+    const { service, storageProvider } = createDependencies();
+
+    await assert.rejects(
+        () => uploadWithDefaults(service, { fields: { isPublic: 'yes' } }),
+        /isPublic/,
+    );
+    assert.equal(storageProvider.calls.length, 0);
+});
+
+test('returns DTO from imageService.createImage', async () => {
+    const dto = { id: 'image-1', imageUrl: 'http://localhost/media/image-1.jpg' };
+    const { service } = createDependencies({ dto });
+
+    const result = await uploadWithDefaults(service);
+
+    assert.equal(result, dto);
+});
+
+test('does not expose storageKey in returned DTO when imageService returns safe DTO', async () => {
+    const { service } = createDependencies({
+        dto: { id: 'image-1', imageUrl: 'http://localhost/media/image-1.jpg' },
+    });
+
+    const result = await uploadWithDefaults(service);
+
+    assert.equal(Object.prototype.hasOwnProperty.call(result, 'storageKey'), false);
+});
+
+test('cleans up main image if thumbnail save fails', async () => {
+    const thumbnailKey = 'users/user-1/thumbnails/image-1.webp';
+    const saveError = new Error('thumbnail save failed');
+    const { service, storageProvider } = createDependencies({
+        processed: createProcessedImage({
+            thumbnailBuffer: Buffer.from('processed-thumb'),
+            thumbnailExtension: 'webp',
+        }),
+        throwOnSaveKey: thumbnailKey,
+        saveError,
+    });
+
+    await assert.rejects(
+        () => uploadWithDefaults(service),
+        (error) => error === saveError,
+    );
+    assert.deepEqual(storageProvider.calls.map((call) => `${call.method}:${call.input?.storageKey || call.storageKey}`), [
+        'saveObject:users/user-1/images/image-1.jpg',
+        'saveObject:users/user-1/thumbnails/image-1.webp',
+        'deleteObject:users/user-1/images/image-1.jpg',
+    ]);
+});
+
+test('cleans up saved objects if metadata creation fails', async () => {
+    const metadataError = new Error('metadata failed');
+    const { service, storageProvider } = createDependencies({
+        processed: createProcessedImage({
+            thumbnailBuffer: Buffer.from('processed-thumb'),
+            thumbnailExtension: 'webp',
+        }),
+        metadataError,
+    });
+
+    await assert.rejects(
+        () => uploadWithDefaults(service),
+        (error) => error === metadataError,
+    );
+    assert.deepEqual(storageProvider.calls.map((call) => `${call.method}:${call.input?.storageKey || call.storageKey}`), [
+        'saveObject:users/user-1/images/image-1.jpg',
+        'saveObject:users/user-1/thumbnails/image-1.webp',
+        'deleteObject:users/user-1/images/image-1.jpg',
+        'deleteObject:users/user-1/thumbnails/image-1.webp',
+    ]);
+});
+
+test('propagates original processing error', async () => {
+    const processingError = new Error('processing failed');
+    const { service } = createDependencies({ processingError });
+
+    await assert.rejects(
+        () => uploadWithDefaults(service),
+        (error) => error === processingError,
+    );
+});
+
+test('propagates original storage save error', async () => {
+    const saveError = new Error('save failed');
+    const { service } = createDependencies({
+        throwOnSaveKey: 'users/user-1/images/image-1.jpg',
+        saveError,
+    });
+
+    await assert.rejects(
+        () => uploadWithDefaults(service),
+        (error) => error === saveError,
+    );
+});
+
+test('propagates original metadata error', async () => {
+    const metadataError = new Error('metadata failed');
+    const { service } = createDependencies({ metadataError });
+
+    await assert.rejects(
+        () => uploadWithDefaults(service),
+        (error) => error === metadataError,
+    );
+});
+
+test('does not mutate file', async () => {
+    const { service } = createDependencies();
+    const file = createFile();
+    const before = JSON.stringify(file);
+
+    await uploadWithDefaults(service, { file });
+
+    assert.equal(JSON.stringify(file), before);
+});
+
+test('does not mutate fields', async () => {
+    const { service } = createDependencies();
+    const fields = { title: 'Title', isPublic: 'false' };
+    const before = JSON.stringify(fields);
+
+    await uploadWithDefaults(service, { fields });
+
+    assert.equal(JSON.stringify(fields), before);
+});
+
+test('does not mutate currentUser', async () => {
+    const { service } = createDependencies();
+    const currentUser = createCurrentUser();
+    const before = JSON.stringify(currentUser);
+
+    await uploadWithDefaults(service, { currentUser });
+
+    assert.equal(JSON.stringify(currentUser), before);
+});

--- a/tests/localStorageProvider.test.js
+++ b/tests/localStorageProvider.test.js
@@ -1,0 +1,375 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs/promises');
+const path = require('path');
+const os = require('os');
+const { Readable } = require('stream');
+
+const { createLocalStorageProvider } = require('../storage/localStorageProvider');
+
+const createTempContext = async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'photogram-local-storage-'));
+    return {
+        root,
+        config: {
+            localStorageRoot: root,
+            publicMediaBaseUrl: 'http://localhost:3000/media',
+        },
+        cleanup: () => fs.rm(root, { recursive: true, force: true }),
+    };
+};
+
+const readStreamToString = async (readableStream) => {
+    const chunks = [];
+    for await (const chunk of readableStream) {
+        chunks.push(Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks).toString('utf8');
+};
+
+const assertProviderError = async (callback, messagePart) => {
+    await assert.rejects(
+        callback,
+        (error) => error instanceof Error && error.message.includes(messagePart),
+    );
+};
+
+test('creates a local storage provider', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+
+        assert.equal(typeof provider.saveObject, 'function');
+        assert.equal(typeof provider.deleteObject, 'function');
+        assert.equal(typeof provider.getUrl, 'function');
+        assert.equal(typeof provider.createReadStream, 'function');
+        assert.equal(typeof provider.objectExists, 'function');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects missing config', () => {
+    assert.throws(
+        () => createLocalStorageProvider(),
+        /config/,
+    );
+});
+
+test('rejects missing config.localStorageRoot', () => {
+    assert.throws(
+        () => createLocalStorageProvider({ config: { publicMediaBaseUrl: 'http://localhost/media' } }),
+        /config\.localStorageRoot/,
+    );
+});
+
+test('rejects missing config.publicMediaBaseUrl', () => {
+    assert.throws(
+        () => createLocalStorageProvider({ config: { localStorageRoot: '/tmp/images' } }),
+        /config\.publicMediaBaseUrl/,
+    );
+});
+
+test('saves a readable stream to disk', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await provider.saveObject({
+            storageKey: 'users/u1/images/a.txt',
+            readableStream: Readable.from(['stream-data']),
+        });
+
+        const content = await fs.readFile(path.join(context.root, 'users/u1/images/a.txt'), 'utf8');
+        assert.equal(content, 'stream-data');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('saves a buffer to disk', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await provider.saveObject({
+            storageKey: 'users/u1/images/b.txt',
+            buffer: Buffer.from('buffer-data'),
+        });
+
+        const content = await fs.readFile(path.join(context.root, 'users/u1/images/b.txt'), 'utf8');
+        assert.equal(content, 'buffer-data');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('creates nested parent directories', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await provider.saveObject({
+            storageKey: 'a/b/c/d.txt',
+            buffer: Buffer.from('nested'),
+        });
+
+        const stats = await fs.stat(path.join(context.root, 'a/b/c'));
+        assert.equal(stats.isDirectory(), true);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('returns storageKey and sizeBytes from saveObject', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        const result = await provider.saveObject({
+            storageKey: 'image.txt',
+            buffer: Buffer.from('12345'),
+        });
+
+        assert.deepEqual(result, {
+            storageKey: 'image.txt',
+            sizeBytes: 5,
+        });
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects save when neither readableStream nor buffer is provided', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await assertProviderError(
+            () => provider.saveObject({ storageKey: 'missing.txt' }),
+            'readableStream or buffer',
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects empty storage keys', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await assertProviderError(
+            () => provider.saveObject({ storageKey: '', buffer: Buffer.from('x') }),
+            'storageKey',
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects absolute storage keys', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await assertProviderError(
+            () => provider.saveObject({ storageKey: path.resolve('/tmp/escape.txt'), buffer: Buffer.from('x') }),
+            'absolute paths',
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects storage keys with .. segments', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await assertProviderError(
+            () => provider.saveObject({ storageKey: 'users/../escape.txt', buffer: Buffer.from('x') }),
+            '.. path segments',
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects storage keys with backslashes', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await assertProviderError(
+            () => provider.saveObject({ storageKey: 'users\\u1\\image.txt', buffer: Buffer.from('x') }),
+            'backslashes',
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects storage keys with null bytes', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await assertProviderError(
+            () => provider.saveObject({ storageKey: 'image\0.txt', buffer: Buffer.from('x') }),
+            'null bytes',
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects storage keys ending in /', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await assertProviderError(
+            () => provider.saveObject({ storageKey: 'users/u1/', buffer: Buffer.from('x') }),
+            'end with /',
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects path traversal that would escape LOCAL_STORAGE_ROOT', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await assertProviderError(
+            () => provider.saveObject({ storageKey: 'safe/%2e%2e/escape.txt/../../escape.txt', buffer: Buffer.from('x') }),
+            '.. path segments',
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects overwriting an existing object by default', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await provider.saveObject({ storageKey: 'same.txt', buffer: Buffer.from('first') });
+
+        await assertProviderError(
+            () => provider.saveObject({ storageKey: 'same.txt', buffer: Buffer.from('second') }),
+            'already exists',
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('overwrites an existing object when overwrite === true', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await provider.saveObject({ storageKey: 'same.txt', buffer: Buffer.from('first') });
+        await provider.saveObject({ storageKey: 'same.txt', buffer: Buffer.from('second'), overwrite: true });
+
+        const content = await fs.readFile(path.join(context.root, 'same.txt'), 'utf8');
+        assert.equal(content, 'second');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('deletes an existing object and returns deleted: true', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await provider.saveObject({ storageKey: 'delete-me.txt', buffer: Buffer.from('x') });
+
+        const result = await provider.deleteObject('delete-me.txt');
+
+        assert.deepEqual(result, { storageKey: 'delete-me.txt', deleted: true });
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('deleting a missing object returns deleted: false', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+
+        const result = await provider.deleteObject('missing.txt');
+
+        assert.deepEqual(result, { storageKey: 'missing.txt', deleted: false });
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('objectExists returns true for an existing file', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await provider.saveObject({ storageKey: 'exists.txt', buffer: Buffer.from('x') });
+
+        assert.equal(await provider.objectExists('exists.txt'), true);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('objectExists returns false for a missing file', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+
+        assert.equal(await provider.objectExists('missing.txt'), false);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('createReadStream streams the stored content without buffering the whole file', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+        await provider.saveObject({ storageKey: 'read.txt', buffer: Buffer.from('read-stream-content') });
+
+        const readableStream = provider.createReadStream('read.txt');
+        assert.equal(typeof readableStream.pipe, 'function');
+        assert.equal(await readStreamToString(readableStream), 'read-stream-content');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('getUrl joins publicMediaBaseUrl and storageKey', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+
+        assert.equal(provider.getUrl('users/u1/images/photo.webp'), 'http://localhost:3000/media/users/u1/images/photo.webp');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('getUrl removes trailing slash from publicMediaBaseUrl', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({
+            config: {
+                localStorageRoot: context.root,
+                publicMediaBaseUrl: 'http://localhost:3000/media///',
+            },
+        });
+
+        assert.equal(provider.getUrl('photo.webp'), 'http://localhost:3000/media/photo.webp');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('getUrl URL-encodes path segments while preserving /', async () => {
+    const context = await createTempContext();
+    try {
+        const provider = createLocalStorageProvider({ config: context.config });
+
+        assert.equal(
+            provider.getUrl('users/user 1/images/photo one.webp'),
+            'http://localhost:3000/media/users/user%201/images/photo%20one.webp',
+        );
+    } finally {
+        await context.cleanup();
+    }
+});

--- a/tests/providerRegistry.test.js
+++ b/tests/providerRegistry.test.js
@@ -1,0 +1,341 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs/promises');
+const path = require('path');
+const os = require('os');
+
+const { createContainer } = require('../config/container');
+const { createProviderRegistry } = require('../config/providerRegistry');
+
+const createFakeFirebaseAuth = () => {
+    const calls = [];
+    return {
+        calls,
+        async verifyIdToken(token) {
+            calls.push(token);
+            return { uid: 'user-1' };
+        },
+    };
+};
+
+const createTempContext = async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'photogram-provider-registry-'));
+    return {
+        tempDir,
+        cleanup: () => fs.rm(tempDir, { recursive: true, force: true }),
+    };
+};
+
+const createMvpConfig = (tempDir, overrides = {}) => ({
+    nodeEnv: 'test',
+    port: 3000,
+    authProvider: 'firebase',
+    databaseProvider: 'sqlite',
+    storageProvider: 'local',
+    sqlitePath: path.join(tempDir, 'photogram.sqlite'),
+    localStorageRoot: path.join(tempDir, 'images'),
+    publicMediaBaseUrl: 'http://localhost:3000/media',
+    firebaseServiceAccountPath: '/fake/service-account.json',
+    firebaseStorageBucket: '',
+    firebaseUrlMode: 'signed',
+    firebaseSignedUrlExpiresSeconds: 300,
+    lowMemoryMode: true,
+    maxFileSizeMb: 5,
+    resizeConcurrency: 1,
+    heavyRateLimitMax: 8,
+    enableDebugEndpoint: false,
+    imageProcessor: 'sharp',
+    ...overrides,
+});
+
+const createMvpContainerContext = async () => {
+    const context = await createTempContext();
+    const firebaseAuth = createFakeFirebaseAuth();
+    const dependencies = { firebaseAuth };
+    const registry = createProviderRegistry(dependencies);
+    const config = createMvpConfig(context.tempDir);
+    const container = createContainer(config, registry);
+
+    return {
+        ...context,
+        config,
+        dependencies,
+        firebaseAuth,
+        registry,
+        container,
+        cleanup: async () => {
+            await container.imageRepository.close().catch(() => {});
+            await context.cleanup();
+        },
+    };
+};
+
+test('creates a provider registry', () => {
+    const registry = createProviderRegistry();
+
+    assert.equal(typeof registry, 'object');
+});
+
+test('registry exposes authProviders', () => {
+    const registry = createProviderRegistry();
+
+    assert.equal(typeof registry.authProviders, 'object');
+});
+
+test('registry exposes imageRepositories', () => {
+    const registry = createProviderRegistry();
+
+    assert.equal(typeof registry.imageRepositories, 'object');
+});
+
+test('registry exposes storageProviders', () => {
+    const registry = createProviderRegistry();
+
+    assert.equal(typeof registry.storageProviders, 'object');
+});
+
+test('registry includes authProviders.firebase', () => {
+    const registry = createProviderRegistry();
+
+    assert.equal(typeof registry.authProviders.firebase, 'function');
+});
+
+test('registry includes imageRepositories.sqlite', () => {
+    const registry = createProviderRegistry();
+
+    assert.equal(typeof registry.imageRepositories.sqlite, 'function');
+});
+
+test('registry includes storageProviders.local', () => {
+    const registry = createProviderRegistry();
+
+    assert.equal(typeof registry.storageProviders.local, 'function');
+});
+
+test('registry does not include unimplemented authProviders.local', () => {
+    const registry = createProviderRegistry();
+
+    assert.equal(Object.prototype.hasOwnProperty.call(registry.authProviders, 'local'), false);
+});
+
+test('registry does not include unimplemented imageRepositories.firebase', () => {
+    const registry = createProviderRegistry();
+
+    assert.equal(Object.prototype.hasOwnProperty.call(registry.imageRepositories, 'firebase'), false);
+});
+
+test('registry does not include unimplemented storageProviders.firebase', () => {
+    const registry = createProviderRegistry();
+
+    assert.equal(Object.prototype.hasOwnProperty.call(registry.storageProviders, 'firebase'), false);
+});
+
+test('MVP provider combination can be passed to createContainer', async () => {
+    const context = await createMvpContainerContext();
+    try {
+        assert.equal(context.container.config, context.config);
+        assert.equal(typeof context.container.authProvider.getCurrentUser, 'function');
+        assert.equal(typeof context.container.imageRepository.createImage, 'function');
+        assert.equal(typeof context.container.storageProvider.getUrl, 'function');
+        assert.equal(typeof context.container.imagePresenter.toImageDto, 'function');
+        assert.equal(typeof context.container.imageService.createImage, 'function');
+        assert.equal(typeof context.container.imageUploadService.uploadImage, 'function');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('constructed MVP container includes authProvider', async () => {
+    const context = await createMvpContainerContext();
+    try {
+        assert.equal(typeof context.container.authProvider.getCurrentUser, 'function');
+        assert.equal(typeof context.container.authProvider.requireUser, 'function');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('constructed MVP container includes imageRepository', async () => {
+    const context = await createMvpContainerContext();
+    try {
+        assert.equal(typeof context.container.imageRepository.createImage, 'function');
+        assert.equal(typeof context.container.imageRepository.close, 'function');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('constructed MVP container includes storageProvider', async () => {
+    const context = await createMvpContainerContext();
+    try {
+        assert.equal(typeof context.container.storageProvider.saveObject, 'function');
+        assert.equal(typeof context.container.storageProvider.getUrl, 'function');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('constructed MVP container includes imagePresenter', async () => {
+    const context = await createMvpContainerContext();
+    try {
+        assert.equal(typeof context.container.imagePresenter.toImageDto, 'function');
+        assert.equal(typeof context.container.imagePresenter.toImageDtos, 'function');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('constructed MVP container includes imageService', async () => {
+    const context = await createMvpContainerContext();
+    try {
+        assert.equal(typeof context.container.imageService.listPublicImages, 'function');
+        assert.equal(typeof context.container.imageService.listUserImages, 'function');
+        assert.equal(typeof context.container.imageService.findImageById, 'function');
+        assert.equal(typeof context.container.imageService.createImage, 'function');
+        assert.equal(typeof context.container.imageService.updateImageVisibility, 'function');
+        assert.equal(typeof context.container.imageService.archiveImage, 'function');
+        assert.equal(typeof context.container.imageService.unarchiveImage, 'function');
+        assert.equal(typeof context.container.imageService.deleteImage, 'function');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('constructed MVP container includes imageUploadService', async () => {
+    const context = await createMvpContainerContext();
+    try {
+        assert.equal(typeof context.container.imageUploadService.uploadImage, 'function');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('constructed MVP image service can create image metadata using SQLite and return a DTO', async () => {
+    const context = await createMvpContainerContext();
+    try {
+        const dto = await context.container.imageService.createImage({
+            id: 'image-1',
+            storageKey: 'users/user-1/images/image-1.webp',
+            thumbnailKey: 'users/user-1/thumbnails/image-1.webp',
+            isPublic: true,
+        }, {
+            uid: 'user-1',
+        });
+
+        assert.equal(dto.id, 'image-1');
+        assert.equal(dto.ownerId, 'user-1');
+        assert.equal(dto.imageUrl, 'http://localhost:3000/media/users/user-1/images/image-1.webp');
+        assert.equal(dto.thumbnailUrl, 'http://localhost:3000/media/users/user-1/thumbnails/image-1.webp');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('returned DTO includes imageUrl', async () => {
+    const context = await createMvpContainerContext();
+    try {
+        const dto = await context.container.imageService.createImage({
+            id: 'image-1',
+            storageKey: 'users/user-1/images/image-1.webp',
+            isPublic: true,
+        }, {
+            uid: 'user-1',
+        });
+
+        assert.equal(dto.imageUrl, 'http://localhost:3000/media/users/user-1/images/image-1.webp');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('returned DTO does not include storageKey', async () => {
+    const context = await createMvpContainerContext();
+    try {
+        const dto = await context.container.imageService.createImage({
+            id: 'image-1',
+            storageKey: 'users/user-1/images/image-1.webp',
+            isPublic: true,
+        }, {
+            uid: 'user-1',
+        });
+
+        assert.equal(Object.prototype.hasOwnProperty.call(dto, 'storageKey'), false);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('returned DTO does not include thumbnailKey', async () => {
+    const context = await createMvpContainerContext();
+    try {
+        const dto = await context.container.imageService.createImage({
+            id: 'image-1',
+            storageKey: 'users/user-1/images/image-1.webp',
+            thumbnailKey: 'users/user-1/thumbnails/image-1.webp',
+            isPublic: true,
+        }, {
+            uid: 'user-1',
+        });
+
+        assert.equal(Object.prototype.hasOwnProperty.call(dto, 'thumbnailKey'), false);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('Firebase auth provider receives injected fake firebaseAuth', async () => {
+    const context = await createMvpContainerContext();
+    try {
+        const user = await context.container.authProvider.getCurrentUser({
+            headers: {
+                authorization: 'Bearer token-1',
+            },
+        });
+
+        assert.equal(user.uid, 'user-1');
+        assert.deepEqual(context.firebaseAuth.calls, ['token-1']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('SQLite repository can be closed after registry/container construction', async () => {
+    const context = await createMvpContainerContext();
+    await context.container.imageRepository.close();
+    await context.cleanup();
+});
+
+test('provider registry does not read real .env', async () => {
+    const context = await createTempContext();
+    const originalEnv = process.env;
+    process.env = {
+        AUTH_PROVIDER: 'local',
+        DATABASE_PROVIDER: 'firebase',
+        STORAGE_PROVIDER: 'firebase',
+    };
+
+    try {
+        const registry = createProviderRegistry({ firebaseAuth: createFakeFirebaseAuth() });
+        const container = createContainer(createMvpConfig(context.tempDir), registry);
+        await container.imageRepository.close();
+
+        assert.equal(typeof container.authProvider.getCurrentUser, 'function');
+        assert.equal(typeof container.imageRepository.createImage, 'function');
+        assert.equal(typeof container.storageProvider.saveObject, 'function');
+    } finally {
+        process.env = originalEnv;
+        await context.cleanup();
+    }
+});
+
+test('provider registry does not mutate passed dependencies', () => {
+    const firebaseAuth = createFakeFirebaseAuth();
+    const dependencies = { firebaseAuth };
+    const beforeKeys = Object.keys(dependencies);
+    const beforeFirebaseAuth = dependencies.firebaseAuth;
+
+    createProviderRegistry(dependencies);
+
+    assert.deepEqual(Object.keys(dependencies), beforeKeys);
+    assert.equal(dependencies.firebaseAuth, beforeFirebaseAuth);
+});

--- a/tests/sqliteImageRepository.test.js
+++ b/tests/sqliteImageRepository.test.js
@@ -1,0 +1,790 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs/promises');
+const path = require('path');
+const os = require('os');
+const Database = require('better-sqlite3');
+
+const { createSqliteImageRepository } = require('../repositories/sqliteImageRepository');
+
+const createTempContext = async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'photogram-sqlite-repo-'));
+    return {
+        tempDir,
+        sqlitePath: path.join(tempDir, 'nested', 'photogram.sqlite'),
+        cleanup: () => fs.rm(tempDir, { recursive: true, force: true }),
+    };
+};
+
+const createRepositoryContext = async () => {
+    const context = await createTempContext();
+    const repository = createSqliteImageRepository({
+        config: {
+            sqlitePath: context.sqlitePath,
+        },
+    });
+
+    return {
+        ...context,
+        repository,
+        cleanup: async () => {
+            await repository.close().catch(() => {});
+            await context.cleanup();
+        },
+    };
+};
+
+const createImageData = (overrides = {}) => ({
+    id: 'img-1',
+    ownerId: 'owner-1',
+    storageKey: 'users/owner-1/images/img-1.webp',
+    ...overrides,
+});
+
+const createImage = (repository, overrides = {}) =>
+    repository.createImage(createImageData(overrides));
+
+test('creates a SQLite image repository', async () => {
+    const context = await createRepositoryContext();
+    try {
+        assert.equal(typeof context.repository.listPublicImages, 'function');
+        assert.equal(typeof context.repository.listImagesByOwner, 'function');
+        assert.equal(typeof context.repository.findImageById, 'function');
+        assert.equal(typeof context.repository.createImage, 'function');
+        assert.equal(typeof context.repository.updateImageVisibility, 'function');
+        assert.equal(typeof context.repository.archiveImageById, 'function');
+        assert.equal(typeof context.repository.unarchiveImageById, 'function');
+        assert.equal(typeof context.repository.deleteImageById, 'function');
+        assert.equal(typeof context.repository.close, 'function');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects missing config', () => {
+    assert.throws(
+        () => createSqliteImageRepository(),
+        /config/,
+    );
+});
+
+test('rejects missing config.sqlitePath', () => {
+    assert.throws(
+        () => createSqliteImageRepository({ config: {} }),
+        /config\.sqlitePath/,
+    );
+});
+
+test('creates the database parent directory', async () => {
+    const context = await createRepositoryContext();
+    try {
+        const stats = await fs.stat(path.dirname(context.sqlitePath));
+        assert.equal(stats.isDirectory(), true);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('initializes the images table', async () => {
+    const context = await createRepositoryContext();
+    try {
+        const created = await createImage(context.repository);
+        assert.equal(created.id, 'img-1');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('schema includes archived_at', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await context.repository.close();
+        const db = new Database(context.sqlitePath);
+        try {
+            const columns = db.prepare('PRAGMA table_info(images)').all();
+            assert.equal(columns.some((column) => column.name === 'archived_at'), true);
+        } finally {
+            db.close();
+        }
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('migrates existing images table with archived_at', async () => {
+    const context = await createTempContext();
+    await fs.mkdir(path.dirname(context.sqlitePath), { recursive: true });
+    const db = new Database(context.sqlitePath);
+    db.exec(`
+        CREATE TABLE images (
+            id TEXT PRIMARY KEY,
+            owner_id TEXT NOT NULL,
+            title TEXT,
+            description TEXT,
+            storage_key TEXT NOT NULL,
+            thumbnail_key TEXT,
+            mime_type TEXT,
+            width INTEGER,
+            height INTEGER,
+            size_bytes INTEGER,
+            is_public INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL,
+            updated_at TEXT,
+            deleted_at TEXT
+        );
+    `);
+    db.close();
+
+    const repository = createSqliteImageRepository({
+        config: {
+            sqlitePath: context.sqlitePath,
+        },
+    });
+
+    try {
+        await repository.close();
+        const migratedDb = new Database(context.sqlitePath);
+        try {
+            const columns = migratedDb.prepare('PRAGMA table_info(images)').all();
+            assert.equal(columns.some((column) => column.name === 'archived_at'), true);
+        } finally {
+            migratedDb.close();
+        }
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('creates an image with required fields', async () => {
+    const context = await createRepositoryContext();
+    try {
+        const image = await createImage(context.repository);
+
+        assert.equal(image.id, 'img-1');
+        assert.equal(image.ownerId, 'owner-1');
+        assert.equal(image.storageKey, 'users/owner-1/images/img-1.webp');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('defaults optional fields', async () => {
+    const context = await createRepositoryContext();
+    try {
+        const image = await createImage(context.repository);
+
+        assert.equal(image.title, null);
+        assert.equal(image.description, null);
+        assert.equal(image.thumbnailKey, null);
+        assert.equal(image.mimeType, null);
+        assert.equal(image.width, null);
+        assert.equal(image.height, null);
+        assert.equal(image.sizeBytes, null);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('defaults isPublic to true', async () => {
+    const context = await createRepositoryContext();
+    try {
+        const image = await createImage(context.repository);
+        assert.equal(image.isPublic, true);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('defaults archivedAt to null', async () => {
+    const context = await createRepositoryContext();
+    try {
+        const image = await createImage(context.repository);
+        assert.equal(image.archivedAt, null);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('defaults createdAt and updatedAt', async () => {
+    const context = await createRepositoryContext();
+    try {
+        const image = await createImage(context.repository);
+
+        assert.match(image.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+        assert.equal(image.updatedAt, image.createdAt);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('returns camelCase image fields', async () => {
+    const context = await createRepositoryContext();
+    try {
+        const image = await createImage(context.repository, {
+            title: 'Title',
+            description: 'Description',
+            thumbnailKey: 'thumb.webp',
+            mimeType: 'image/webp',
+            width: 640,
+            height: 480,
+            sizeBytes: 123,
+            isPublic: false,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-02T00:00:00.000Z',
+        });
+
+        assert.deepEqual(Object.keys(image), [
+            'id',
+            'ownerId',
+            'title',
+            'description',
+            'storageKey',
+            'thumbnailKey',
+            'mimeType',
+            'width',
+            'height',
+            'sizeBytes',
+            'isPublic',
+            'createdAt',
+            'updatedAt',
+            'deletedAt',
+            'archivedAt',
+        ]);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('stores storage keys but does not return imageUrl', async () => {
+    const context = await createRepositoryContext();
+    try {
+        const image = await createImage(context.repository);
+
+        assert.equal(image.storageKey, 'users/owner-1/images/img-1.webp');
+        assert.equal(Object.prototype.hasOwnProperty.call(image, 'imageUrl'), false);
+        assert.equal(Object.prototype.hasOwnProperty.call(image, 'thumbnailUrl'), false);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects missing image id', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await assert.rejects(
+            () => context.repository.createImage(createImageData({ id: '' })),
+            /id/,
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects missing ownerId', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await assert.rejects(
+            () => context.repository.createImage(createImageData({ ownerId: '' })),
+            /ownerId/,
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects missing storageKey', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await assert.rejects(
+            () => context.repository.createImage(createImageData({ storageKey: '' })),
+            /storageKey/,
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects duplicate id', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository);
+
+        await assert.rejects(
+            () => createImage(context.repository),
+            /id/,
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('finds an existing image by id', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository);
+
+        const image = await context.repository.findImageById('img-1');
+
+        assert.equal(image.id, 'img-1');
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('returns null for a missing image id', async () => {
+    const context = await createRepositoryContext();
+    try {
+        assert.equal(await context.repository.findImageById('missing'), null);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('excludes soft-deleted rows from findImageById by default', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository);
+        await context.repository.deleteImageById('img-1', 'owner-1');
+
+        assert.equal(await context.repository.findImageById('img-1'), null);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('includes soft-deleted rows when includeDeleted === true', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository);
+        await context.repository.deleteImageById('img-1', 'owner-1');
+
+        const image = await context.repository.findImageById('img-1', { includeDeleted: true });
+
+        assert.equal(image.id, 'img-1');
+        assert.match(image.deletedAt, /^\d{4}-\d{2}-\d{2}T/);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('lists only public images from listPublicImages', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { id: 'public', isPublic: true });
+        await createImage(context.repository, { id: 'private', isPublic: false });
+
+        const images = await context.repository.listPublicImages();
+
+        assert.deepEqual(images.map((image) => image.id), ['public']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('excludes private images from listPublicImages', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { id: 'private', isPublic: false });
+
+        const images = await context.repository.listPublicImages();
+
+        assert.equal(images.length, 0);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('excludes soft-deleted images from listPublicImages', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { id: 'deleted', isPublic: true });
+        await context.repository.deleteImageById('deleted', 'owner-1');
+
+        const images = await context.repository.listPublicImages();
+
+        assert.equal(images.length, 0);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('excludes archived images from listPublicImages', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { id: 'active', isPublic: true });
+        await createImage(context.repository, { id: 'archived', isPublic: true });
+        await context.repository.archiveImageById('archived', 'owner-1');
+
+        const images = await context.repository.listPublicImages();
+
+        assert.deepEqual(images.map((image) => image.id), ['active']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('lists only images for the requested owner from listImagesByOwner', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { id: 'owner-1-image', ownerId: 'owner-1' });
+        await createImage(context.repository, { id: 'owner-2-image', ownerId: 'owner-2' });
+
+        const images = await context.repository.listImagesByOwner('owner-1');
+
+        assert.deepEqual(images.map((image) => image.id), ['owner-1-image']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('excludes other owners from listImagesByOwner', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { id: 'other-owner', ownerId: 'owner-2' });
+
+        const images = await context.repository.listImagesByOwner('owner-1');
+
+        assert.equal(images.length, 0);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('excludes soft-deleted rows from listImagesByOwner', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { id: 'deleted' });
+        await context.repository.deleteImageById('deleted', 'owner-1');
+
+        const images = await context.repository.listImagesByOwner('owner-1');
+
+        assert.equal(images.length, 0);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('listImagesByOwner excludes archived rows by default', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { id: 'active' });
+        await createImage(context.repository, { id: 'archived' });
+        await context.repository.archiveImageById('archived', 'owner-1');
+
+        const images = await context.repository.listImagesByOwner('owner-1');
+
+        assert.deepEqual(images.map((image) => image.id), ['active']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('listImagesByOwner archived=true returns archived only', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { id: 'active' });
+        await createImage(context.repository, { id: 'archived' });
+        await context.repository.archiveImageById('archived', 'owner-1');
+
+        const images = await context.repository.listImagesByOwner('owner-1', { archived: true });
+
+        assert.deepEqual(images.map((image) => image.id), ['archived']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('listImagesByOwner includeArchived=true returns both archived and active rows', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { id: 'active', createdAt: '2026-01-02T00:00:00.000Z' });
+        await createImage(context.repository, { id: 'archived', createdAt: '2026-01-01T00:00:00.000Z' });
+        await context.repository.archiveImageById('archived', 'owner-1');
+
+        const images = await context.repository.listImagesByOwner('owner-1', { includeArchived: true });
+
+        assert.deepEqual(images.map((image) => image.id), ['active', 'archived']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('orders list results by createdAt descending', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { id: 'older', createdAt: '2026-01-01T00:00:00.000Z' });
+        await createImage(context.repository, { id: 'newer', createdAt: '2026-01-02T00:00:00.000Z' });
+
+        const images = await context.repository.listPublicImages();
+
+        assert.deepEqual(images.map((image) => image.id), ['newer', 'older']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('supports limit', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { id: 'one', createdAt: '2026-01-01T00:00:00.000Z' });
+        await createImage(context.repository, { id: 'two', createdAt: '2026-01-02T00:00:00.000Z' });
+
+        const images = await context.repository.listPublicImages({ limit: 1 });
+
+        assert.deepEqual(images.map((image) => image.id), ['two']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('supports offset', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { id: 'one', createdAt: '2026-01-01T00:00:00.000Z' });
+        await createImage(context.repository, { id: 'two', createdAt: '2026-01-02T00:00:00.000Z' });
+
+        const images = await context.repository.listPublicImages({ offset: 1 });
+
+        assert.deepEqual(images.map((image) => image.id), ['one']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('caps limit at 200', async () => {
+    const context = await createRepositoryContext();
+    try {
+        for (let index = 0; index < 205; index += 1) {
+            await createImage(context.repository, {
+                id: `img-${index}`,
+                storageKey: `images/img-${index}.webp`,
+                createdAt: `2026-01-01T00:00:${String(index % 60).padStart(2, '0')}.000Z`,
+            });
+        }
+
+        const images = await context.repository.listPublicImages({ limit: 500 });
+
+        assert.equal(images.length, 200);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects invalid limit', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await assert.rejects(
+            () => context.repository.listPublicImages({ limit: 0 }),
+            /limit/,
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('rejects invalid offset', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await assert.rejects(
+            () => context.repository.listPublicImages({ offset: -1 }),
+            /offset/,
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('update visibility changes isPublic', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { isPublic: true });
+
+        const image = await context.repository.updateImageVisibility('img-1', 'owner-1', false);
+
+        assert.equal(image.isPublic, false);
+        assert.match(image.updatedAt, /^\d{4}-\d{2}-\d{2}T/);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('update visibility requires owner', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, { isPublic: true });
+
+        const image = await context.repository.updateImageVisibility('img-1', 'owner-2', false);
+
+        assert.equal(image, null);
+        assert.equal((await context.repository.findImageById('img-1')).isPublic, true);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('update visibility requires boolean isPublic', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await assert.rejects(
+            () => context.repository.updateImageVisibility('img-1', 'owner-1', 'false'),
+            /isPublic/,
+        );
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('archive sets archivedAt', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository);
+
+        const image = await context.repository.archiveImageById('img-1', 'owner-1');
+
+        assert.match(image.archivedAt, /^\d{4}-\d{2}-\d{2}T/);
+        assert.equal(image.updatedAt, image.archivedAt);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('archive requires owner', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository);
+
+        const image = await context.repository.archiveImageById('img-1', 'owner-2');
+
+        assert.equal(image, null);
+        assert.equal((await context.repository.findImageById('img-1')).archivedAt, null);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('archive does not delete storage metadata', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, {
+            storageKey: 'users/owner-1/images/img-1.webp',
+            thumbnailKey: 'users/owner-1/thumbnails/img-1.webp',
+        });
+
+        const image = await context.repository.archiveImageById('img-1', 'owner-1');
+
+        assert.equal(image.storageKey, 'users/owner-1/images/img-1.webp');
+        assert.equal(image.thumbnailKey, 'users/owner-1/thumbnails/img-1.webp');
+        assert.equal(image.deletedAt, null);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('unarchive clears archivedAt', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository);
+        await context.repository.archiveImageById('img-1', 'owner-1');
+
+        const image = await context.repository.unarchiveImageById('img-1', 'owner-1');
+
+        assert.equal(image.archivedAt, null);
+        assert.match(image.updatedAt, /^\d{4}-\d{2}-\d{2}T/);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('archive and visibility updates exclude soft-deleted rows', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository);
+        await context.repository.deleteImageById('img-1', 'owner-1');
+
+        assert.equal(await context.repository.updateImageVisibility('img-1', 'owner-1', false), null);
+        assert.equal(await context.repository.archiveImageById('img-1', 'owner-1'), null);
+        assert.equal(await context.repository.unarchiveImageById('img-1', 'owner-1'), null);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('soft-deletes an image by id and owner', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository);
+        await context.repository.deleteImageById('img-1', 'owner-1');
+
+        const image = await context.repository.findImageById('img-1', { includeDeleted: true });
+
+        assert.match(image.deletedAt, /^\d{4}-\d{2}-\d{2}T/);
+        assert.equal(image.updatedAt, image.deletedAt);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('delete returns deleted: true when a row is newly soft-deleted', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository);
+
+        const result = await context.repository.deleteImageById('img-1', 'owner-1');
+
+        assert.deepEqual(result, { imageId: 'img-1', deleted: true });
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('delete returns deleted: false when image id does not exist', async () => {
+    const context = await createRepositoryContext();
+    try {
+        const result = await context.repository.deleteImageById('missing', 'owner-1');
+
+        assert.deepEqual(result, { imageId: 'missing', deleted: false });
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('delete returns deleted: false when owner id does not match', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository);
+
+        const result = await context.repository.deleteImageById('img-1', 'owner-2');
+
+        assert.deepEqual(result, { imageId: 'img-1', deleted: false });
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('delete returns deleted: false when image is already soft-deleted', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository);
+        await context.repository.deleteImageById('img-1', 'owner-1');
+
+        const result = await context.repository.deleteImageById('img-1', 'owner-1');
+
+        assert.deepEqual(result, { imageId: 'img-1', deleted: false });
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('close closes the database connection', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await context.repository.close();
+
+        await assert.rejects(
+            () => createImage(context.repository),
+            /database connection is not open|closed/i,
+        );
+    } finally {
+        await context.cleanup();
+    }
+});

--- a/tests/staticMedia.test.js
+++ b/tests/staticMedia.test.js
@@ -1,0 +1,341 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { Readable } = require('node:stream');
+
+const { createStaticMediaMiddleware } = require('../middleware/staticMedia');
+
+const createStorageProvider = (overrides = {}) => {
+    const calls = [];
+    const existingKeys = new Set(overrides.existingKeys || [
+        'users/user-1/images/image-1.webp',
+        'users/user-1/images/image-1.jpg',
+        'users/user-1/images/image-1.png',
+        'users/user 1/images/photo one.webp',
+    ]);
+
+    return {
+        calls,
+        objectExists: overrides.objectExists || (async (storageKey) => {
+            calls.push({ method: 'objectExists', storageKey });
+            return existingKeys.has(storageKey);
+        }),
+        createReadStream: overrides.createReadStream || ((storageKey) => {
+            calls.push({ method: 'createReadStream', storageKey });
+            return Readable.from([`content:${storageKey}`]);
+        }),
+    };
+};
+
+const requestMiddleware = async (middleware, options) => {
+    const nextCalls = [];
+    const server = http.createServer((req, res) => {
+        const next = (error) => {
+            nextCalls.push(error);
+            res.statusCode = error ? 599 : 204;
+            res.end(error ? 'next:error' : 'next');
+        };
+
+        middleware(req, res, next);
+    });
+
+    await new Promise((resolve) => server.listen(0, resolve));
+    const { port } = server.address();
+
+    try {
+        const response = await new Promise((resolve, reject) => {
+            const req = http.request({
+                hostname: '127.0.0.1',
+                port,
+                path: options.path,
+                method: options.method || 'GET',
+            }, (res) => {
+                let body = '';
+                res.setEncoding('utf8');
+                res.on('data', (chunk) => {
+                    body += chunk;
+                });
+                res.on('end', () => {
+                    resolve({
+                        statusCode: res.statusCode,
+                        headers: res.headers,
+                        body,
+                        json: body && res.headers['content-type'] && res.headers['content-type'].includes('application/json')
+                            ? JSON.parse(body)
+                            : null,
+                    });
+                });
+            });
+
+            req.on('error', reject);
+            req.end();
+        });
+
+        return {
+            ...response,
+            nextCalls,
+        };
+    } finally {
+        await new Promise((resolve) => server.close(resolve));
+    }
+};
+
+test('creates static media middleware', () => {
+    const middleware = createStaticMediaMiddleware({
+        storageProvider: createStorageProvider(),
+    });
+
+    assert.equal(typeof middleware, 'function');
+});
+
+test('rejects missing storageProvider', () => {
+    assert.throws(
+        () => createStaticMediaMiddleware(),
+        /storageProvider/,
+    );
+});
+
+test('rejects missing storageProvider.objectExists', () => {
+    assert.throws(
+        () => createStaticMediaMiddleware({
+            storageProvider: {
+                createReadStream: () => Readable.from([]),
+            },
+        }),
+        /storageProvider\.objectExists/,
+    );
+});
+
+test('rejects missing storageProvider.createReadStream', () => {
+    assert.throws(
+        () => createStaticMediaMiddleware({
+            storageProvider: {
+                objectExists: async () => true,
+            },
+        }),
+        /storageProvider\.createReadStream/,
+    );
+});
+
+test('streams an existing .webp object', async () => {
+    const storageProvider = createStorageProvider();
+    const middleware = createStaticMediaMiddleware({ storageProvider });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/user-1/images/image-1.webp',
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.body, 'content:users/user-1/images/image-1.webp');
+});
+
+test('streams an existing .jpg object', async () => {
+    const storageProvider = createStorageProvider();
+    const middleware = createStaticMediaMiddleware({ storageProvider });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/user-1/images/image-1.jpg',
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.body, 'content:users/user-1/images/image-1.jpg');
+});
+
+test('returns 404 when object does not exist', async () => {
+    const storageProvider = createStorageProvider();
+    const middleware = createStaticMediaMiddleware({ storageProvider });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/user-1/images/missing.webp',
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.deepEqual(response.json, { error: 'Media not found' });
+});
+
+test('returns 400 for missing media path', async () => {
+    const middleware = createStaticMediaMiddleware({
+        storageProvider: createStorageProvider(),
+    });
+
+    const response = await requestMiddleware(middleware, { path: '/' });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(response.json, { error: 'Invalid media path' });
+});
+
+test('returns 400 for .. path segments', async () => {
+    const middleware = createStaticMediaMiddleware({
+        storageProvider: createStorageProvider(),
+    });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/../image.webp',
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(response.json, { error: 'Invalid media path' });
+});
+
+test('returns 400 for encoded traversal', async () => {
+    const middleware = createStaticMediaMiddleware({
+        storageProvider: createStorageProvider(),
+    });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/%2e%2e/image.webp',
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(response.json, { error: 'Invalid media path' });
+});
+
+test('returns 400 for backslashes', async () => {
+    const middleware = createStaticMediaMiddleware({
+        storageProvider: createStorageProvider(),
+    });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/user-1/images%5Cimage.webp',
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(response.json, { error: 'Invalid media path' });
+});
+
+test('returns 400 for null bytes', async () => {
+    const middleware = createStaticMediaMiddleware({
+        storageProvider: createStorageProvider(),
+    });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/user-1/images/image%00.webp',
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(response.json, { error: 'Invalid media path' });
+});
+
+test('returns 400 for malformed percent-encoding', async () => {
+    const middleware = createStaticMediaMiddleware({
+        storageProvider: createStorageProvider(),
+    });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/%E0%A4%A/image.webp',
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(response.json, { error: 'Invalid media path' });
+});
+
+test('returns 400 for unsupported extension', async () => {
+    const middleware = createStaticMediaMiddleware({
+        storageProvider: createStorageProvider(),
+    });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/user-1/images/image.txt',
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(response.json, { error: 'Invalid media path' });
+});
+
+test('decodes URL-encoded path segments', async () => {
+    const storageProvider = createStorageProvider();
+    const middleware = createStaticMediaMiddleware({ storageProvider });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/user%201/images/photo%20one.webp',
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(storageProvider.calls[0], {
+        method: 'objectExists',
+        storageKey: 'users/user 1/images/photo one.webp',
+    });
+});
+
+test('preserves / separators in storage keys', async () => {
+    const storageProvider = createStorageProvider();
+    const middleware = createStaticMediaMiddleware({ storageProvider });
+
+    await requestMiddleware(middleware, {
+        path: '/users/user-1/images/image-1.webp',
+    });
+
+    assert.equal(storageProvider.calls[0].storageKey, 'users/user-1/images/image-1.webp');
+});
+
+test('sets correct Content-Type', async () => {
+    const middleware = createStaticMediaMiddleware({
+        storageProvider: createStorageProvider(),
+    });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/user-1/images/image-1.png',
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.headers['content-type'], 'image/png');
+});
+
+test('sets Cache-Control on successful responses', async () => {
+    const middleware = createStaticMediaMiddleware({
+        storageProvider: createStorageProvider(),
+    });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/user-1/images/image-1.webp',
+    });
+
+    assert.equal(response.headers['cache-control'], 'public, max-age=31536000, immutable');
+});
+
+test('supports HEAD without a response body', async () => {
+    const storageProvider = createStorageProvider();
+    const middleware = createStaticMediaMiddleware({ storageProvider });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/user-1/images/image-1.webp',
+        method: 'HEAD',
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.body, '');
+    assert.deepEqual(storageProvider.calls.map((call) => call.method), ['objectExists']);
+});
+
+test('calls next() for non-GET/non-HEAD methods', async () => {
+    const middleware = createStaticMediaMiddleware({
+        storageProvider: createStorageProvider(),
+    });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/user-1/images/image-1.webp',
+        method: 'POST',
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(response.nextCalls.length, 1);
+    assert.equal(response.nextCalls[0], undefined);
+});
+
+test('calls next(error) when createReadStream throws before headers are sent', async () => {
+    const error = new Error('stream setup failed');
+    const storageProvider = createStorageProvider({
+        createReadStream: () => {
+            throw error;
+        },
+    });
+    const middleware = createStaticMediaMiddleware({ storageProvider });
+
+    const response = await requestMiddleware(middleware, {
+        path: '/users/user-1/images/image-1.webp',
+    });
+
+    assert.equal(response.statusCode, 599);
+    assert.equal(response.nextCalls.length, 1);
+    assert.equal(response.nextCalls[0], error);
+});


### PR DESCRIPTION
## Summary

This PR adds the provider-backed MVP backend for Photogram. Firebase is now optional for image metadata and storage: the MVP mode uses Firebase Auth for identity, SQLite for image metadata, and local filesystem storage for image files.

The backend now owns provider selection, image processing, storage mutation, metadata persistence, and API response shaping. The frontend can use the same Photogram API regardless of whether the backend is using Firebase, SQLite/local storage, or another future provider.

## Provider mode added

MVP provider configuration:

```env
AUTH_PROVIDER=firebase
DATABASE_PROVIDER=sqlite
STORAGE_PROVIDER=local
````

Local storage and SQLite configuration:

```env
SQLITE_PATH=./data/photogram.sqlite
LOCAL_STORAGE_ROOT=./data/images
PUBLIC_MEDIA_BASE_URL=http://localhost:3003/media
```

NC110-safe runtime profile remains supported:

```env
LOW_MEMORY_MODE=true
IMAGE_PROCESSOR=jimp
MAX_FILE_SIZE_MB=5
RESIZE_CONCURRENCY=1
HEAVY_RATE_LIMIT_MAX=8
ENABLE_DEBUG_ENDPOINT=false
```

## Behavior changes

Added provider-backed canonical routes:

```text
GET    /images/public
GET    /images/me
POST   /images
DELETE /images/:imageId
PATCH  /images/:imageId/visibility
POST   /images/:imageId/archive
POST   /images/:imageId/unarchive
GET    /media/*
```

Preserved legacy routes:

```text
/health
/resize
/upload
/resize-upload
/delete-image
```

Key backend changes:

* Added centralized env parsing and validation.
* Added provider container and explicit provider registry.
* Added Firebase Auth provider for token verification.
* Added SQLite image repository.
* Added local filesystem storage provider.
* Added image presenter to return frontend-safe DTOs.
* Added provider-backed image service and upload service.
* Added canonical image API routes.
* Added static local media serving through `/media`.
* Added archive/unarchive and hide/show metadata support.
* Added lazy Firebase Storage bucket initialization so local-storage MVP startup does not require a Firebase Storage bucket.
* Updated CORS methods to support provider-backed image API calls, including `PATCH` and `DELETE`.

## API examples

Public gallery:

```bash
curl http://localhost:3003/images/public
```

Authenticated user gallery:

```bash
curl -H "Authorization: Bearer <firebase-id-token>" \
  http://localhost:3003/images/me
```

Upload:

```bash
curl -X POST \
  -H "Authorization: Bearer <firebase-id-token>" \
  -F "image=@/path/to/photo.jpg" \
  -F "description=Provider-backed upload" \
  -F "isPublic=true" \
  http://localhost:3003/images
```

Delete:

```bash
curl -X DELETE \
  -H "Authorization: Bearer <firebase-id-token>" \
  http://localhost:3003/images/<image-id>
```

Hide/show:

```bash
curl -X PATCH \
  -H "Authorization: Bearer <firebase-id-token>" \
  -H "Content-Type: application/json" \
  -d '{"isPublic":false}' \
  http://localhost:3003/images/<image-id>/visibility
```

Archive:

```bash
curl -X POST \
  -H "Authorization: Bearer <firebase-id-token>" \
  http://localhost:3003/images/<image-id>/archive
```

Unarchive:

```bash
curl -X POST \
  -H "Authorization: Bearer <firebase-id-token>" \
  http://localhost:3003/images/<image-id>/unarchive
```

Archived view:

```bash
curl -H "Authorization: Bearer <firebase-id-token>" \
  "http://localhost:3003/images/me?archived=true"
```

## Security and provider boundary

* Service account JSON remains outside the repository.
* `.env`, `secrets/`, SQLite data, uploaded image data, `firebase-debug.log`, and `node_modules/` were not committed.
* Provider selection is centralized in config/container/provider-registry code.
* Controllers/routes/services do not import concrete SQLite/local-storage/Firebase provider implementations.
* API DTOs do not expose `storageKey`, `thumbnailKey`, filesystem paths, or Firebase bucket internals.
* Firebase Storage bucket initialization is lazy and only required when legacy Firebase Storage behavior is actually used.

## Tests

Automated checks passed:

```bash
npm test
```

Result:

```text
440 tests passed, 0 failed
```

Syntax checks passed for touched backend files, including:

```text
index.js
app.js
config/env.js
config/container.js
config/providerRegistry.js
config/firebase.js
auth/firebaseAuthProvider.js
storage/localStorageProvider.js
repositories/sqliteImageRepository.js
services/imagePresenter.js
services/imageService.js
services/imageUploadService.js
services/imageProcessor.js
controllers/imageApiController.js
controllers/imageController.js
routes/imageApiRoutes.js
routes/imageRoutes.js
middleware/staticMedia.js
middleware/cors.js
```

## Manual validation

Run backend locally with:

```bash
PORT=3003 npm start
```

Then verify:

```text
GET    /health
GET    /images/public
GET    /images/me
POST   /images
DELETE /images/:imageId
PATCH  /images/:imageId/visibility
POST   /images/:imageId/archive
POST   /images/:imageId/unarchive
GET    /media/*
POST   /resize-upload
```

## Deployment notes / risks

* `better-sqlite3` and `sharp` are native dependencies; verify installation on the NC110.
* If `sharp` is unstable on Atom-era hardware, use `IMAGE_PROCESSOR=jimp`.
* Keep `LOW_MEMORY_MODE=true`, `RESIZE_CONCURRENCY=1`, and `MAX_FILE_SIZE_MB=5` on the NC110.
* SQLite DB and `LOCAL_STORAGE_ROOT` must be backed up together.
* Express `/media` serving is acceptable for low traffic; Nginx/Caddy static serving can be considered later.
