### PR TITLE
feat: add image tag support to upload API

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Auth requirements:
 
 - `GET /images/public` — no auth; lists public, non-archived image DTOs.
 - `GET /images/me` — Firebase ID token required; lists current user's images. Supports `?archived=true` and `?includeArchived=true`.
-- `POST /images` — Firebase ID token required; uploads one image using multipart field `image`.
+- `POST /images` — Firebase ID token required; uploads one image using multipart field `image`. Optional `tags` must be a JSON array string.
 - `DELETE /images/:imageId` — Firebase ID token required; deletes owned storage objects and soft-deletes metadata.
 - `PATCH /images/:imageId/visibility` — Firebase ID token required; updates `isPublic` for an owned image.
 - `POST /images/:imageId/archive` — Firebase ID token required; archives an owned image without deleting files.
@@ -138,6 +138,7 @@ Auth requirements:
 - `GET /media/*` — public local media serving when `STORAGE_PROVIDER=local`.
 
 DTO responses intentionally hide provider internals such as `storageKey`, `thumbnailKey`, filesystem paths, bucket names, and signed URL internals.
+Tagged image DTOs include `tags` and `tagSlugs`; untagged images return empty arrays for both fields.
 
 ## Legacy Routes
 
@@ -190,6 +191,7 @@ curl -X POST \
   -F "image=@/path/to/photo.jpg" \
   -F "description=Provider-backed upload" \
   -F "isPublic=true" \
+  -F 'tags=["dog","golden retriever","New York"]' \
   http://localhost:3003/images
 ```
 

--- a/controllers/imageApiController.js
+++ b/controllers/imageApiController.js
@@ -1,3 +1,5 @@
+const { tagToSlug } = require('../utils/tags');
+
 const VALIDATION_ERROR = 'VALIDATION_ERROR';
 
 const createValidationError = (message) => {
@@ -59,6 +61,13 @@ const parsePaginationOptions = (query = {}) => {
     }
     if (offset !== undefined) {
         options.offset = offset;
+    }
+    if (Object.prototype.hasOwnProperty.call(query, 'tag')) {
+        const tag = query.tag;
+        if (Array.isArray(tag) || typeof tag !== 'string' || tag.trim() === '') {
+            throw createValidationError('tag must be a non-empty string.');
+        }
+        options.tag = tagToSlug(tag);
     }
 
     return options;

--- a/controllers/imageController.js
+++ b/controllers/imageController.js
@@ -4,6 +4,7 @@ const { v4: uuid } = require('uuid');
 
 const { log, logError } = require('../utils/logger');
 const { resolveStorageUrl } = require('../utils/storageUrl');
+const { normalizeTags } = require('../utils/tags');
 
 const getSharp = () => require('sharp');
 const getJimp = () => require('jimp');
@@ -27,6 +28,14 @@ const hasValidImageFile = (req, res, invalidMimetypeMessage = 'Uploaded file is 
         return false;
     }
     return true;
+};
+
+const sendValidationError = (res, error) => {
+    if (error && error.statusCode === 400) {
+        res.status(400).json({ error: error.message });
+        return true;
+    }
+    return false;
 };
 
 const createImageController = ({
@@ -82,6 +91,7 @@ const createImageController = ({
         if (!hasValidImageFile(req, res)) return;
 
         try {
+            const tagData = normalizeTags(req.body && req.body.tags);
             const mime = req.file.mimetype || 'application/octet-stream';
             const mimeToExt = {
                 'image/jpeg': 'jpg',
@@ -115,8 +125,9 @@ const createImageController = ({
                 urlMode,
                 signedUrlExpiresSeconds,
             });
-            res.json({ url });
+            res.json({ url, ...tagData });
         } catch (error) {
+            if (sendValidationError(res, error)) return;
             logError('Error uploading to Firebase Storage', error);
             res.status(500).json({ error: 'Failed to upload image to Firebase', details: error.message });
         } finally {
@@ -131,6 +142,7 @@ const createImageController = ({
         log('info', 'Received file for resize-upload', { filename: req.file.originalname });
 
         try {
+            const tagData = normalizeTags(req.body && req.body.tags);
             const fileName = `images/${uuid()}.jpg`;
             log('info', 'Uploading resized image', { fileName });
 
@@ -176,8 +188,9 @@ const createImageController = ({
                 urlMode,
                 signedUrlExpiresSeconds,
             });
-            res.json({ url });
+            res.json({ url, ...tagData });
         } catch (error) {
+            if (sendValidationError(res, error)) return;
             const message = String(error?.message || '');
             if (message.includes('Input file is missing') || message.includes('unsupported image format') || message.includes('corrupt')) {
                 return res.status(400).json({ error: 'Invalid image file.' });

--- a/middleware/errorHandlers.js
+++ b/middleware/errorHandlers.js
@@ -12,6 +12,9 @@ const multerErrorHandler = (err, req, res, next) => {
 
 const fallbackErrorHandler = (err, req, res, next) => {
     logError('Unhandled server error', err);
+    if (Number.isInteger(err.statusCode) && err.statusCode >= 400 && err.statusCode < 500) {
+        return res.status(err.statusCode).json({ error: err.message });
+    }
     return res.status(500).json({ error: 'Internal server error' });
 };
 

--- a/repositories/sqliteImageRepository.js
+++ b/repositories/sqliteImageRepository.js
@@ -43,9 +43,31 @@ const normalizePagination = (options = {}) => {
     };
 };
 
+const normalizeTagPattern = (options = {}) => {
+    if (options.tag === undefined || options.tag === null || options.tag === '') {
+        return undefined;
+    }
+    if (typeof options.tag !== 'string' || !/^[a-z0-9-]+$/.test(options.tag)) {
+        throw new Error('tag must be a lowercase tag slug.');
+    }
+    return `%"${options.tag}"%`;
+};
+
 const toSqliteBoolean = (value) => (value === false ? 0 : 1);
 
 const nowIso = () => new Date().toISOString();
+
+const parseJsonArray = (value) => {
+    if (!value) return [];
+    try {
+        const parsed = JSON.parse(value);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+        return [];
+    }
+};
+
+const stringifyArray = (value) => JSON.stringify(Array.isArray(value) ? value : []);
 
 const mapRowToImage = (row) => {
     if (!row) return null;
@@ -66,6 +88,8 @@ const mapRowToImage = (row) => {
         updatedAt: row.updated_at,
         deletedAt: row.deleted_at,
         archivedAt: row.archived_at,
+        tags: parseJsonArray(row.tags),
+        tagSlugs: parseJsonArray(row.tag_slugs),
     };
 };
 
@@ -95,7 +119,9 @@ const initializeSchema = (db) => {
             created_at TEXT NOT NULL,
             updated_at TEXT,
             deleted_at TEXT,
-            archived_at TEXT
+            archived_at TEXT,
+            tags TEXT,
+            tag_slugs TEXT
         );
 
         CREATE INDEX IF NOT EXISTS idx_images_public_created
@@ -109,10 +135,15 @@ const initializeSchema = (db) => {
     `);
 
     ensureColumn(db, 'images', 'archived_at', 'archived_at TEXT');
+    ensureColumn(db, 'images', 'tags', 'tags TEXT');
+    ensureColumn(db, 'images', 'tag_slugs', 'tag_slugs TEXT');
 
     db.exec(`
         CREATE INDEX IF NOT EXISTS idx_images_archived
         ON images (archived_at);
+
+        CREATE INDEX IF NOT EXISTS idx_images_tag_slugs
+        ON images (tag_slugs);
     `);
 };
 
@@ -141,7 +172,9 @@ const createSqliteImageRepository = ({ config } = {}) => {
             created_at,
             updated_at,
             deleted_at,
-            archived_at
+            archived_at,
+            tags,
+            tag_slugs
         ) VALUES (
             @id,
             @ownerId,
@@ -157,7 +190,9 @@ const createSqliteImageRepository = ({ config } = {}) => {
             @createdAt,
             @updatedAt,
             NULL,
-            NULL
+            NULL,
+            @tags,
+            @tagSlugs
         )
     `);
     const findByIdActive = db.prepare('SELECT * FROM images WHERE id = ? AND deleted_at IS NULL');
@@ -170,11 +205,29 @@ const createSqliteImageRepository = ({ config } = {}) => {
         ORDER BY created_at DESC
         LIMIT @limit OFFSET @offset
     `);
+    const listPublicByTag = db.prepare(`
+        SELECT * FROM images
+        WHERE is_public = 1
+            AND deleted_at IS NULL
+            AND archived_at IS NULL
+            AND tag_slugs LIKE @tagPattern
+        ORDER BY created_at DESC
+        LIMIT @limit OFFSET @offset
+    `);
     const listByOwnerActive = db.prepare(`
         SELECT * FROM images
         WHERE owner_id = @ownerId
             AND deleted_at IS NULL
             AND archived_at IS NULL
+        ORDER BY created_at DESC
+        LIMIT @limit OFFSET @offset
+    `);
+    const listByOwnerActiveByTag = db.prepare(`
+        SELECT * FROM images
+        WHERE owner_id = @ownerId
+            AND deleted_at IS NULL
+            AND archived_at IS NULL
+            AND tag_slugs LIKE @tagPattern
         ORDER BY created_at DESC
         LIMIT @limit OFFSET @offset
     `);
@@ -186,10 +239,27 @@ const createSqliteImageRepository = ({ config } = {}) => {
         ORDER BY created_at DESC
         LIMIT @limit OFFSET @offset
     `);
+    const listByOwnerArchivedByTag = db.prepare(`
+        SELECT * FROM images
+        WHERE owner_id = @ownerId
+            AND deleted_at IS NULL
+            AND archived_at IS NOT NULL
+            AND tag_slugs LIKE @tagPattern
+        ORDER BY created_at DESC
+        LIMIT @limit OFFSET @offset
+    `);
     const listByOwnerAll = db.prepare(`
         SELECT * FROM images
         WHERE owner_id = @ownerId
             AND deleted_at IS NULL
+        ORDER BY created_at DESC
+        LIMIT @limit OFFSET @offset
+    `);
+    const listByOwnerAllByTag = db.prepare(`
+        SELECT * FROM images
+        WHERE owner_id = @ownerId
+            AND deleted_at IS NULL
+            AND tag_slugs LIKE @tagPattern
         ORDER BY created_at DESC
         LIMIT @limit OFFSET @offset
     `);
@@ -247,6 +317,8 @@ const createSqliteImageRepository = ({ config } = {}) => {
             isPublic: toSqliteBoolean(imageData.isPublic),
             createdAt,
             updatedAt,
+            tags: stringifyArray(imageData.tags),
+            tagSlugs: stringifyArray(imageData.tagSlugs),
         };
 
         try {
@@ -272,19 +344,26 @@ const createSqliteImageRepository = ({ config } = {}) => {
 
     const listPublicImages = async (options = {}) => {
         const pagination = normalizePagination(options);
-        return listPublic.all(pagination).map(mapRowToImage);
+        const tagPattern = normalizeTagPattern(options);
+        const statement = tagPattern ? listPublicByTag : listPublic;
+        return statement.all({ ...pagination, tagPattern }).map(mapRowToImage);
     };
 
     const listImagesByOwner = async (ownerId, options = {}) => {
         requireNonEmptyString(ownerId, 'ownerId');
         const pagination = normalizePagination(options);
-        const statement = options.archived === true
-            ? listByOwnerArchived
-            : options.includeArchived === true
-                ? listByOwnerAll
-                : listByOwnerActive;
+        const tagPattern = normalizeTagPattern(options);
+        let statement;
 
-        return statement.all({ ownerId, ...pagination }).map(mapRowToImage);
+        if (options.archived === true) {
+            statement = tagPattern ? listByOwnerArchivedByTag : listByOwnerArchived;
+        } else if (options.includeArchived === true) {
+            statement = tagPattern ? listByOwnerAllByTag : listByOwnerAll;
+        } else {
+            statement = tagPattern ? listByOwnerActiveByTag : listByOwnerActive;
+        }
+
+        return statement.all({ ownerId, ...pagination, tagPattern }).map(mapRowToImage);
     };
 
     const updateImageVisibility = async (imageId, ownerId, isPublic) => {

--- a/services/imagePresenter.js
+++ b/services/imagePresenter.js
@@ -17,6 +17,8 @@ const assignIfPresent = (target, key, value) => {
     }
 };
 
+const normalizeArray = (value) => (Array.isArray(value) ? [...value] : []);
+
 const createUrlOptions = (imageRecord, kind) => ({
     visibility: Boolean(imageRecord.isPublic) ? 'public' : 'private',
     kind,
@@ -58,6 +60,8 @@ function createImagePresenter({ storageProvider } = {}) {
         assignIfPresent(dto, 'mimeType', imageRecord.mimeType);
         dto.isPublic = isPublic;
         dto.isArchived = Boolean(imageRecord.archivedAt);
+        dto.tags = normalizeArray(imageRecord.tags);
+        dto.tagSlugs = normalizeArray(imageRecord.tagSlugs);
         dto.createdAt = imageRecord.createdAt;
         assignIfPresent(dto, 'updatedAt', imageRecord.updatedAt);
         assignIfPresent(dto, 'archivedAt', imageRecord.archivedAt);

--- a/services/imageUploadService.js
+++ b/services/imageUploadService.js
@@ -1,6 +1,7 @@
 const { v4: uuid } = require('uuid');
 
 const { cleanTempFile } = require('./imageProcessor');
+const { normalizeTags } = require('../utils/tags');
 
 const VALIDATION_ERROR = 'VALIDATION_ERROR';
 const UNAUTHENTICATED = 'UNAUTHENTICATED';
@@ -192,6 +193,7 @@ function createImageUploadService({
             const title = parseOptionalString(uploadFields, 'title');
             const description = parseOptionalString(uploadFields, 'description');
             const isPublic = parseIsPublic(uploadFields);
+            const { tags, tagSlugs } = normalizeTags(uploadFields.tags);
             const savedStorageKeys = [];
 
             const processed = await processImage(file, {
@@ -248,6 +250,8 @@ function createImageUploadService({
                 height: processed.height ?? null,
                 sizeBytes: getSizeBytes(processed, mainSaveResult),
                 isPublic,
+                tags,
+                tagSlugs,
             };
 
             try {

--- a/tests/imageApiController.test.js
+++ b/tests/imageApiController.test.js
@@ -288,6 +288,23 @@ test('listPublicImages passes parsed offset', async () => {
     assert.equal(imageService.calls[0].options.offset, 0);
 });
 
+test('listPublicImages passes normalized tag slug', async () => {
+    const { controller, imageService } = createControllerContext();
+
+    await controller.listPublicImages({ query: { tag: 'New York' } }, createResponse(), createNext());
+
+    assert.equal(imageService.calls[0].options.tag, 'new-york');
+});
+
+test('listPublicImages rejects invalid tag query option', async () => {
+    const { controller } = createControllerContext();
+    const next = createNext();
+
+    await controller.listPublicImages({ query: { tag: 'dog,cat' } }, createResponse(), next);
+
+    assertValidationError(next.calls[0], 'commas');
+});
+
 test('listPublicImages omits pagination options when query is empty', async () => {
     const { controller, imageService } = createControllerContext();
 
@@ -339,6 +356,14 @@ test('listMyImages parses includeArchived query option', async () => {
     await controller.listMyImages({ query: { includeArchived: 'true' } }, createResponse(), createNext());
 
     assert.deepEqual(imageService.calls[0].options, { includeArchived: true });
+});
+
+test('listMyImages parses tag query option', async () => {
+    const { controller, imageService } = createControllerContext();
+
+    await controller.listMyImages({ query: { tag: 'golden retriever' } }, createResponse(), createNext());
+
+    assert.deepEqual(imageService.calls[0].options, { tag: 'golden-retriever' });
 });
 
 test('listMyImages rejects invalid archived query option', async () => {

--- a/tests/imageController.test.js
+++ b/tests/imageController.test.js
@@ -1,5 +1,9 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { Writable } = require('node:stream');
 
 const { createImageController } = require('../controllers/imageController');
 
@@ -39,6 +43,56 @@ const createControllerWithBucketGetter = (bucketGetter) => createImageController
     usePredefinedAcl: true,
     urlMode: 'public',
     signedUrlExpiresSeconds: 900,
+});
+
+const createTempUploadFile = async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'photogram-controller-upload-'));
+    const filePath = path.join(tempDir, 'upload.jpg');
+    await fs.writeFile(filePath, Buffer.from('fake image bytes'));
+
+    return {
+        filePath,
+        cleanup: () => fs.rm(tempDir, { recursive: true, force: true }),
+    };
+};
+
+const createUploadBucket = () => {
+    const writes = [];
+
+    return {
+        name: 'test-bucket',
+        writes,
+        file(fileName) {
+            return {
+                createWriteStream() {
+                    const chunks = [];
+                    return new Writable({
+                        write(chunk, encoding, callback) {
+                            chunks.push(Buffer.from(chunk));
+                            callback();
+                        },
+                        final(callback) {
+                            writes.push({
+                                fileName,
+                                body: Buffer.concat(chunks).toString(),
+                            });
+                            callback();
+                        },
+                    });
+                },
+            };
+        },
+    };
+};
+
+const createUploadRequest = (filePath, body = {}) => ({
+    body,
+    file: {
+        path: filePath,
+        mimetype: 'image/jpeg',
+        size: 16,
+        originalname: 'photo.jpg',
+    },
 });
 
 test('deleteImage returns 400 when imgName is missing', async () => {
@@ -128,4 +182,85 @@ test('deleteImage returns 500 when storage delete fails', async () => {
 
     assert.equal(res.statusCode, 500);
     assert.equal(res.sent, 'Failed to delete the image');
+});
+
+test('upload without tags still works and returns empty tag arrays', async () => {
+    const temp = await createTempUploadFile();
+    const bucket = createUploadBucket();
+    const controller = createController(bucket);
+    const req = createUploadRequest(temp.filePath);
+    const res = createMockResponse();
+
+    try {
+        await controller.upload(req, res);
+
+        assert.equal(res.statusCode, 200);
+        assert.equal(typeof res.jsonPayload.url, 'string');
+        assert.deepEqual(res.jsonPayload.tags, []);
+        assert.deepEqual(res.jsonPayload.tagSlugs, []);
+        assert.equal(bucket.writes.length, 1);
+    } finally {
+        await temp.cleanup();
+    }
+});
+
+test('upload with valid tags returns tags and tagSlugs', async () => {
+    const temp = await createTempUploadFile();
+    const bucket = createUploadBucket();
+    const controller = createController(bucket);
+    const req = createUploadRequest(temp.filePath, {
+        tags: JSON.stringify(['#Dog', 'golden retriever', 'New York']),
+    });
+    const res = createMockResponse();
+
+    try {
+        await controller.upload(req, res);
+
+        assert.deepEqual(res.jsonPayload.tags, ['Dog', 'golden retriever', 'New York']);
+        assert.deepEqual(res.jsonPayload.tagSlugs, ['dog', 'golden-retriever', 'new-york']);
+    } finally {
+        await temp.cleanup();
+    }
+});
+
+test('upload malformed tags field returns 400', async () => {
+    const temp = await createTempUploadFile();
+    let bucketRequested = false;
+    const controller = createControllerWithBucketGetter(() => {
+        bucketRequested = true;
+        return createUploadBucket();
+    });
+    const req = createUploadRequest(temp.filePath, { tags: 'dog,golden retriever' });
+    const res = createMockResponse();
+
+    try {
+        await controller.upload(req, res);
+
+        assert.equal(res.statusCode, 400);
+        assert.match(res.jsonPayload.error, /valid JSON/);
+        assert.equal(bucketRequested, false);
+    } finally {
+        await temp.cleanup();
+    }
+});
+
+test('resizeUpload malformed tags field returns 400', async () => {
+    const temp = await createTempUploadFile();
+    let bucketRequested = false;
+    const controller = createControllerWithBucketGetter(() => {
+        bucketRequested = true;
+        return createUploadBucket();
+    });
+    const req = createUploadRequest(temp.filePath, { tags: 'dog,golden retriever' });
+    const res = createMockResponse();
+
+    try {
+        await controller.resizeUpload(req, res);
+
+        assert.equal(res.statusCode, 400);
+        assert.match(res.jsonPayload.error, /valid JSON/);
+        assert.equal(bucketRequested, false);
+    } finally {
+        await temp.cleanup();
+    }
 });

--- a/tests/imagePresenter.test.js
+++ b/tests/imagePresenter.test.js
@@ -104,6 +104,8 @@ test('maps a full image record to a frontend DTO', async () => {
         mimeType: 'image/webp',
         isPublic: true,
         isArchived: false,
+        tags: [],
+        tagSlugs: [],
         createdAt: '2026-06-22T00:00:00.000Z',
         updatedAt: '2026-06-22T01:00:00.000Z',
     });
@@ -231,6 +233,27 @@ test('preserves archivedAt when present', async () => {
     }));
 
     assert.equal(dto.archivedAt, '2026-06-23T00:00:00.000Z');
+});
+
+test('preserves tags and tagSlugs when present', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord({
+        tags: ['Dog', 'New York'],
+        tagSlugs: ['dog', 'new-york'],
+    }));
+
+    assert.deepEqual(dto.tags, ['Dog', 'New York']);
+    assert.deepEqual(dto.tagSlugs, ['dog', 'new-york']);
+});
+
+test('defaults missing tags to empty arrays', async () => {
+    const presenter = createImagePresenter({ storageProvider: createStorageProvider() });
+
+    const dto = await presenter.toImageDto(createImageRecord());
+
+    assert.deepEqual(dto.tags, []);
+    assert.deepEqual(dto.tagSlugs, []);
 });
 
 test('preserves ownerId', async () => {

--- a/tests/imageUploadService.test.js
+++ b/tests/imageUploadService.test.js
@@ -281,6 +281,8 @@ test('calls imageService.createImage with metadata', async () => {
         height: 960,
         sizeBytes: 14,
         isPublic: true,
+        tags: [],
+        tagSlugs: [],
     });
 });
 
@@ -327,6 +329,29 @@ test('parses isPublic false', async () => {
     });
 
     assert.equal(imageService.calls[0].imageData.isPublic, false);
+});
+
+test('passes normalized tags from fields', async () => {
+    const { service, imageService } = createDependencies();
+
+    await uploadWithDefaults(service, {
+        fields: {
+            tags: JSON.stringify(['#Dog', 'golden   retriever', 'New York', 'dog']),
+        },
+    });
+
+    assert.deepEqual(imageService.calls[0].imageData.tags, ['Dog', 'golden retriever', 'New York']);
+    assert.deepEqual(imageService.calls[0].imageData.tagSlugs, ['dog', 'golden-retriever', 'new-york']);
+});
+
+test('rejects malformed tags before storage writes', async () => {
+    const { service, storageProvider } = createDependencies();
+
+    await assert.rejects(
+        () => uploadWithDefaults(service, { fields: { tags: 'dog,golden retriever' } }),
+        /valid JSON/,
+    );
+    assert.equal(storageProvider.calls.length, 0);
 });
 
 test('rejects invalid isPublic', async () => {

--- a/tests/sqliteImageRepository.test.js
+++ b/tests/sqliteImageRepository.test.js
@@ -103,6 +103,8 @@ test('schema includes archived_at', async () => {
         try {
             const columns = db.prepare('PRAGMA table_info(images)').all();
             assert.equal(columns.some((column) => column.name === 'archived_at'), true);
+            assert.equal(columns.some((column) => column.name === 'tags'), true);
+            assert.equal(columns.some((column) => column.name === 'tag_slugs'), true);
         } finally {
             db.close();
         }
@@ -147,10 +149,86 @@ test('migrates existing images table with archived_at', async () => {
         try {
             const columns = migratedDb.prepare('PRAGMA table_info(images)').all();
             assert.equal(columns.some((column) => column.name === 'archived_at'), true);
+            assert.equal(columns.some((column) => column.name === 'tags'), true);
+            assert.equal(columns.some((column) => column.name === 'tag_slugs'), true);
         } finally {
             migratedDb.close();
         }
     } finally {
+        await context.cleanup();
+    }
+});
+
+test('migrates existing rows without tags and returns empty tag arrays', async () => {
+    const context = await createTempContext();
+    await fs.mkdir(path.dirname(context.sqlitePath), { recursive: true });
+    const db = new Database(context.sqlitePath);
+    db.exec(`
+        CREATE TABLE images (
+            id TEXT PRIMARY KEY,
+            owner_id TEXT NOT NULL,
+            title TEXT,
+            description TEXT,
+            storage_key TEXT NOT NULL,
+            thumbnail_key TEXT,
+            mime_type TEXT,
+            width INTEGER,
+            height INTEGER,
+            size_bytes INTEGER,
+            is_public INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL,
+            updated_at TEXT,
+            deleted_at TEXT
+        );
+
+        INSERT INTO images (
+            id,
+            owner_id,
+            title,
+            description,
+            storage_key,
+            thumbnail_key,
+            mime_type,
+            width,
+            height,
+            size_bytes,
+            is_public,
+            created_at,
+            updated_at,
+            deleted_at
+        ) VALUES (
+            'legacy-1',
+            'owner-1',
+            NULL,
+            NULL,
+            'users/owner-1/images/legacy-1.webp',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            1,
+            '2026-01-01T00:00:00.000Z',
+            '2026-01-01T00:00:00.000Z',
+            NULL
+        );
+    `);
+    db.close();
+
+    const repository = createSqliteImageRepository({
+        config: {
+            sqlitePath: context.sqlitePath,
+        },
+    });
+
+    try {
+        const image = await repository.findImageById('legacy-1');
+
+        assert.deepEqual(image.tags, []);
+        assert.deepEqual(image.tagSlugs, []);
+        assert.equal(image.archivedAt, null);
+    } finally {
+        await repository.close();
         await context.cleanup();
     }
 });
@@ -205,6 +283,18 @@ test('defaults archivedAt to null', async () => {
     }
 });
 
+test('defaults tags and tagSlugs to empty arrays', async () => {
+    const context = await createRepositoryContext();
+    try {
+        const image = await createImage(context.repository);
+
+        assert.deepEqual(image.tags, []);
+        assert.deepEqual(image.tagSlugs, []);
+    } finally {
+        await context.cleanup();
+    }
+});
+
 test('defaults createdAt and updatedAt', async () => {
     const context = await createRepositoryContext();
     try {
@@ -249,6 +339,8 @@ test('returns camelCase image fields', async () => {
             'updatedAt',
             'deletedAt',
             'archivedAt',
+            'tags',
+            'tagSlugs',
         ]);
     } finally {
         await context.cleanup();
@@ -264,6 +356,50 @@ test('stores storage keys but does not return imageUrl', async () => {
         assert.equal(Object.prototype.hasOwnProperty.call(image, 'imageUrl'), false);
         assert.equal(Object.prototype.hasOwnProperty.call(image, 'thumbnailUrl'), false);
     } finally {
+        await context.cleanup();
+    }
+});
+
+test('stores and returns tags and tagSlugs as arrays', async () => {
+    const context = await createRepositoryContext();
+    try {
+        const image = await createImage(context.repository, {
+            tags: ['Dog', 'New York'],
+            tagSlugs: ['dog', 'new-york'],
+        });
+
+        assert.deepEqual(image.tags, ['Dog', 'New York']);
+        assert.deepEqual(image.tagSlugs, ['dog', 'new-york']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('persists tags and tagSlugs after repository close and reopen', async () => {
+    const context = await createRepositoryContext();
+    let reopenedRepository;
+
+    try {
+        await createImage(context.repository, {
+            tags: ['Dog', 'New York'],
+            tagSlugs: ['dog', 'new-york'],
+        });
+        await context.repository.close();
+
+        reopenedRepository = createSqliteImageRepository({
+            config: {
+                sqlitePath: context.sqlitePath,
+            },
+        });
+
+        const image = await reopenedRepository.findImageById('img-1');
+
+        assert.deepEqual(image.tags, ['Dog', 'New York']);
+        assert.deepEqual(image.tagSlugs, ['dog', 'new-york']);
+    } finally {
+        if (reopenedRepository) {
+            await reopenedRepository.close().catch(() => {});
+        }
         await context.cleanup();
     }
 });
@@ -423,6 +559,28 @@ test('excludes archived images from listPublicImages', async () => {
     }
 });
 
+test('listPublicImages filters by tag slug', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, {
+            id: 'dog',
+            tags: ['Dog'],
+            tagSlugs: ['dog'],
+        });
+        await createImage(context.repository, {
+            id: 'cat',
+            tags: ['Cat'],
+            tagSlugs: ['cat'],
+        });
+
+        const images = await context.repository.listPublicImages({ tag: 'dog' });
+
+        assert.deepEqual(images.map((image) => image.id), ['dog']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
 test('lists only images for the requested owner from listImagesByOwner', async () => {
     const context = await createRepositoryContext();
     try {
@@ -504,6 +662,40 @@ test('listImagesByOwner includeArchived=true returns both archived and active ro
         const images = await context.repository.listImagesByOwner('owner-1', { includeArchived: true });
 
         assert.deepEqual(images.map((image) => image.id), ['active', 'archived']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('listImagesByOwner filters by tag slug', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await createImage(context.repository, {
+            id: 'dog',
+            tags: ['Dog'],
+            tagSlugs: ['dog'],
+        });
+        await createImage(context.repository, {
+            id: 'cat',
+            tags: ['Cat'],
+            tagSlugs: ['cat'],
+        });
+
+        const images = await context.repository.listImagesByOwner('owner-1', { tag: 'cat' });
+
+        assert.deepEqual(images.map((image) => image.id), ['cat']);
+    } finally {
+        await context.cleanup();
+    }
+});
+
+test('listImagesByOwner rejects invalid tag slug filters', async () => {
+    const context = await createRepositoryContext();
+    try {
+        await assert.rejects(
+            () => context.repository.listImagesByOwner('owner-1', { tag: 'Dog' }),
+            /tag/,
+        );
     } finally {
         await context.cleanup();
     }

--- a/tests/tags.test.js
+++ b/tests/tags.test.js
@@ -1,0 +1,107 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    MAX_TAGS,
+    MAX_TAG_LENGTH,
+    normalizeTagLabel,
+    tagToSlug,
+    parseTagsField,
+    normalizeTags,
+} = require('../utils/tags');
+
+const assertTagError = (callback, messagePart) => {
+    assert.throws(
+        callback,
+        (error) => error instanceof Error
+            && error.statusCode === 400
+            && error.message.includes(messagePart),
+    );
+};
+
+test('missing tags normalizes to empty arrays', () => {
+    assert.deepEqual(normalizeTags(undefined), { tags: [], tagSlugs: [] });
+    assert.deepEqual(normalizeTags(null), { tags: [], tagSlugs: [] });
+});
+
+test('empty string tags field normalizes to empty arrays', () => {
+    assert.deepEqual(normalizeTags(''), { tags: [], tagSlugs: [] });
+});
+
+test('valid JSON array normalizes correctly', () => {
+    assert.deepEqual(normalizeTags('["dog","golden retriever","New York"]'), {
+        tags: ['dog', 'golden retriever', 'New York'],
+        tagSlugs: ['dog', 'golden-retriever', 'new-york'],
+    });
+});
+
+test('leading # is stripped', () => {
+    assert.equal(normalizeTagLabel('#Dog'), 'Dog');
+    assert.deepEqual(normalizeTags(['##Dog']), {
+        tags: ['Dog'],
+        tagSlugs: ['dog'],
+    });
+});
+
+test('repeated spaces collapse', () => {
+    assert.equal(normalizeTagLabel('golden   retriever'), 'golden retriever');
+});
+
+test('spaces inside tags are preserved', () => {
+    assert.deepEqual(normalizeTags(['New York']), {
+        tags: ['New York'],
+        tagSlugs: ['new-york'],
+    });
+});
+
+test('case-insensitive duplicates are removed', () => {
+    assert.deepEqual(normalizeTags(['Dog', 'dog', '#DOG']), {
+        tags: ['Dog'],
+        tagSlugs: ['dog'],
+    });
+});
+
+test('display casing from first accepted label is preserved', () => {
+    assert.deepEqual(normalizeTags(['New York', 'new york']), {
+        tags: ['New York'],
+        tagSlugs: ['new-york'],
+    });
+});
+
+test('slugs are generated correctly', () => {
+    assert.equal(tagToSlug('Dog'), 'dog');
+    assert.equal(tagToSlug('golden retriever'), 'golden-retriever');
+    assert.equal(tagToSlug('New York'), 'new-york');
+    assert.equal(tagToSlug('Dogs & Cats!'), 'dogs-cats');
+});
+
+test('malformed JSON is rejected', () => {
+    assertTagError(() => parseTagsField('dog,golden retriever'), 'valid JSON');
+});
+
+test('non-array JSON is rejected', () => {
+    assertTagError(() => parseTagsField('{"tag":"dog"}'), 'JSON array');
+});
+
+test('non-string entries are rejected', () => {
+    assertTagError(() => normalizeTags(['dog', 123]), 'strings');
+});
+
+test('more than 10 tags is rejected', () => {
+    const tags = Array.from({ length: MAX_TAGS + 1 }, (_, index) => `tag-${index}`);
+
+    assertTagError(() => normalizeTags(tags), 'more than 10');
+});
+
+test('tag longer than 32 characters is rejected', () => {
+    assert.equal(MAX_TAG_LENGTH, 32);
+    assertTagError(() => normalizeTags(['a'.repeat(MAX_TAG_LENGTH + 1)]), '32 characters');
+});
+
+test('comma inside a final tag is rejected', () => {
+    assertTagError(() => normalizeTags(['dog,cat']), 'commas');
+});
+
+test('control characters are rejected', () => {
+    assertTagError(() => normalizeTags(['dog\ncat']), 'control characters');
+});

--- a/utils/tags.js
+++ b/utils/tags.js
@@ -1,0 +1,123 @@
+const MAX_TAGS = 10;
+const MAX_TAG_LENGTH = 32;
+const CONTROL_CHARACTER_PATTERN = /[\x00-\x1F\x7F]/;
+const UNSAFE_SLUG_CHARACTER_PATTERN = /[^a-z0-9\s-]/g;
+const WHITESPACE_PATTERN = /\s+/g;
+
+const createTagValidationError = (message) => {
+    const error = new Error(message);
+    error.statusCode = 400;
+    error.code = 'VALIDATION_ERROR';
+    return error;
+};
+
+const normalizeTagLabel = (value) => {
+    if (typeof value !== 'string') {
+        throw createTagValidationError('Tags must contain only strings.');
+    }
+    if (CONTROL_CHARACTER_PATTERN.test(value)) {
+        throw createTagValidationError('Tags cannot contain control characters.');
+    }
+
+    const label = value
+        .trim()
+        .replace(/^#+/, '')
+        .trim()
+        .replace(WHITESPACE_PATTERN, ' ');
+
+    if (label === '') {
+        throw createTagValidationError('Tags cannot be empty.');
+    }
+    if (label.length > MAX_TAG_LENGTH) {
+        throw createTagValidationError('Tag labels cannot exceed 32 characters.');
+    }
+    if (label.includes(',')) {
+        throw createTagValidationError('Tags cannot contain commas.');
+    }
+
+    return label;
+};
+
+const tagToSlug = (label) => {
+    const slug = normalizeTagLabel(label)
+        .toLowerCase()
+        .replace(UNSAFE_SLUG_CHARACTER_PATTERN, '')
+        .trim()
+        .replace(WHITESPACE_PATTERN, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+
+    if (slug === '') {
+        throw createTagValidationError('Tag slugs cannot be empty.');
+    }
+
+    return slug;
+};
+
+const parseTagsField = (value) => {
+    if (value === undefined || value === null || value === '') {
+        return [];
+    }
+    if (Array.isArray(value)) {
+        throw createTagValidationError('Tags must be a JSON array string.');
+    }
+    if (typeof value !== 'string') {
+        throw createTagValidationError('Tags must be a JSON array string.');
+    }
+
+    let parsed;
+    try {
+        parsed = JSON.parse(value);
+    } catch (error) {
+        throw createTagValidationError('Tags must be valid JSON.');
+    }
+
+    if (!Array.isArray(parsed)) {
+        throw createTagValidationError('Tags must be a JSON array.');
+    }
+
+    return parsed;
+};
+
+const normalizeTags = (value) => {
+    const values = typeof value === 'string' || value === undefined || value === null
+        ? parseTagsField(value)
+        : value;
+
+    if (!Array.isArray(values)) {
+        throw createTagValidationError('Tags must be a JSON array.');
+    }
+
+    const tags = [];
+    const tagSlugs = [];
+    const seenLabels = new Set();
+
+    for (const item of values) {
+        const label = normalizeTagLabel(item);
+        const dedupeKey = label.toLowerCase();
+
+        if (seenLabels.has(dedupeKey)) {
+            continue;
+        }
+
+        const slug = tagToSlug(label);
+        seenLabels.add(dedupeKey);
+        tags.push(label);
+        tagSlugs.push(slug);
+
+        if (tags.length > MAX_TAGS) {
+            throw createTagValidationError('Tags cannot contain more than 10 items.');
+        }
+    }
+
+    return { tags, tagSlugs };
+};
+
+module.exports = {
+    MAX_TAGS,
+    MAX_TAG_LENGTH,
+    normalizeTagLabel,
+    tagToSlug,
+    parseTagsField,
+    normalizeTags,
+};


### PR DESCRIPTION
## Summary

Adds backend support for image tags across the provider-backed upload flow and legacy upload flows.

Images can now store and return:

- `tags`
- `tagSlugs`

Tags are accepted as an optional multipart form-data field named `tags`, encoded as a JSON array string.

Example:

```json
["dog", "golden retriever", "New York"]
````

## Behavior Changes

* Added shared tag normalization and validation utilities.
* `POST /images` now accepts optional `tags` multipart field.
* Existing uploads without tags remain backward-compatible.
* Missing tags return:

```json
{
  "tags": [],
  "tagSlugs": []
}
```

* SQLite persists `tags` and `tagSlugs` as JSON arrays.
* Existing legacy image rows without tag columns migrate safely and return empty tag arrays.
* Image DTOs now include `tags` and `tagSlugs`.
* Legacy `/upload` and `/resize-upload` validate optional tags and echo normalized arrays.
* Added optional tag filtering on existing list routes:

  * `GET /images/public?tag=golden-retriever`
  * `GET /images/me?tag=golden-retriever`
* Validation errors with `statusCode` now return the intended 4xx response instead of falling through to 500.

## Tag Rules

* Max tags per image: 10.
* Max tag length: 32 characters after trimming.
* Leading/trailing whitespace is trimmed.
* Repeated internal whitespace is collapsed.
* Leading `#` is stripped.
* Empty tags are rejected.
* Commas inside final tag labels are rejected.
* Control characters are rejected.
* Duplicate tags are removed case-insensitively.
* Spaces inside tags are valid.

Examples:

```text
" dog " -> "dog" / "dog"
"#dog" -> "dog" / "dog"
"golden   retriever" -> "golden retriever" / "golden-retriever"
"New York" -> "New York" / "new-york"
```

## API Examples

### Upload with tags

```bash
curl -X POST \
  -H "Authorization: Bearer <firebase-id-token>" \
  -F "image=@/path/to/photo.jpg" \
  -F "description=Provider-backed upload" \
  -F "isPublic=true" \
  -F 'tags=["dog","golden retriever","New York"]' \
  http://localhost:3003/images
```

Expected response shape:

```json
{
  "image": {
    "id": "image-id",
    "imageUrl": "http://localhost:3003/media/users/uid/images/image-id.jpg",
    "tags": ["dog", "golden retriever", "New York"],
    "tagSlugs": ["dog", "golden-retriever", "new-york"]
  }
}
```

### Upload without tags

```bash
curl -X POST \
  -H "Authorization: Bearer <firebase-id-token>" \
  -F "image=@/path/to/photo.jpg" \
  -F "description=No tags" \
  -F "isPublic=true" \
  http://localhost:3003/images
```

Expected response includes:

```json
{
  "image": {
    "tags": [],
    "tagSlugs": []
  }
}
```

### Invalid tags

```bash
curl -X POST \
  -H "Authorization: Bearer <firebase-id-token>" \
  -F "image=@/path/to/photo.jpg" \
  -F "tags=dog,golden retriever" \
  http://localhost:3003/images
```

Expected response:

```json
{
  "error": "Tags must be valid JSON."
}
```

## Privacy Notes

* Provider-backed `POST /images` accepts `isPublic`.
* `isPublic` defaults to `true`.
* Accepted multipart values:

  * `isPublic=true`
  * `isPublic=false`
* `private` is not used by `POST /images`.
* Frontend should map private uploads to `isPublic=false`.
* Legacy `/upload` and `/resize-upload` use the multipart file field `image`, but do not persist metadata/privacy.

## Changed Files

* `utils/tags.js`
* `tests/tags.test.js`
* `services/imageUploadService.js`
* `services/imagePresenter.js`
* `repositories/sqliteImageRepository.js`
* `controllers/imageApiController.js`
* `controllers/imageController.js`
* `middleware/errorHandlers.js`
* `tests/imageUploadService.test.js`
* `tests/imagePresenter.test.js`
* `tests/sqliteImageRepository.test.js`
* `tests/imageApiController.test.js`
* `tests/imageController.test.js`
* `README.md`

## Test Evidence

* `git diff --check`: passed
* `npm test`: passed

  * 484 tests
  * 484 passing
  * 0 failing

Additional focused checks:

* Existing legacy rows without tag columns migrate safely and return `tags: []`, `tagSlugs: []`.
* Tagged metadata persists after repository close/reopen.
* `/upload` malformed tags return 400.
* `/resize-upload` malformed tags return 400.

## Manual Validation Notes

Completed:

* Backend starts locally on port `3003`.
* `/health` returns 200.
* `GET /images/public` returns existing images with `tags: []` and `tagSlugs: []`.
* `GET /images/public?tag=golden-retriever` returns 200 and excludes untagged images.
* Malformed tags on legacy upload routes return 400.

Blocked by environment:

* Authenticated `POST /images` 2xx curl verification requires a valid Firebase ID token.
* Legacy successful `/upload` and `/resize-upload` checks are blocked by Firebase Storage billing/project configuration.

These are environment/auth blockers, not known backend tag-code blockers.

## Deployment Notes

* Back up the SQLite database before deploying.
* Confirm migrations/legacy rows are safe after deploy.
* Confirm backend boots under PM2.
* Check:

  * `/health`
  * `/images/public`
  * authenticated `POST /images`
* No new heavy dependencies were added.